### PR TITLE
Add Pet weight for the API

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -20,6 +20,7 @@ import org.springframework.beans.support.PropertyComparator;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -48,6 +49,9 @@ public class Pet extends NamedEntity {
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
     private Set<Visit> visits;
+
+    @Column(name = "weight", precision = 5, scale = 2)
+    private BigDecimal weight;
 
     public LocalDate getBirthDate() {
         return this.birthDate;
@@ -97,6 +101,14 @@ public class Pet extends NamedEntity {
     public void addVisit(Visit visit) {
         getVisitsInternal().add(visit);
         visit.setPet(this);
+    }
+
+    public BigDecimal getWeight() {
+        return this.weight;
+    }
+
+    public void setWeight(BigDecimal weight) {
+        this.weight = weight;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -115,7 +115,7 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", owner.getId());
         final List<JdbcPet> pets = this.namedParameterJdbcTemplate.query(
-            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
+            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
             params,
             new JdbcPetVisitExtractor()
         );

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -110,7 +110,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
         } else {
             this.namedParameterJdbcTemplate.update(
                 "UPDATE pets SET name=:name, birth_date=:birth_date, type_id=:type_id, " +
-                    "owner_id=:owner_id WHERE id=:id",
+                    "owner_id=:owner_id, weight=:weight WHERE id=:id",
                 createPetParameterSource(pet));
         }
     }
@@ -124,7 +124,8 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             .addValue("name", pet.getName())
             .addValue("birth_date", pet.getBirthDate())
             .addValue("type_id", pet.getType().getId())
-            .addValue("owner_id", pet.getOwner().getId());
+            .addValue("owner_id", pet.getOwner().getId())
+            .addValue("weight", pet.getWeight());
     }
     
 	@Override
@@ -133,7 +134,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
 		Collection<Pet> pets = new ArrayList<Pet>();
 		Collection<JdbcPet> jdbcPets = new ArrayList<JdbcPet>();
 		jdbcPets = this.namedParameterJdbcTemplate
-				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets",
+				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets",
 				params,
 				new JdbcPetRowMapper());
 		Collection<PetType> petTypes = this.namedParameterJdbcTemplate.query("SELECT id, name FROM types ORDER BY name",

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.repository.jdbc;
 
 import org.springframework.jdbc.core.RowMapper;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -36,6 +37,7 @@ public class JdbcPetRowMapper implements RowMapper<JdbcPet> {
         pet.setBirthDate(rs.getObject("birth_date", LocalDate.class));
         pet.setTypeId(rs.getInt("type_id"));
         pet.setOwnerId(rs.getInt("owner_id"));
+        pet.setWeight(rs.getBigDecimal("weight"));
         return pet;
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
@@ -119,9 +119,9 @@ public class JdbcPetTypeRepositoryImpl implements PetTypeRepository {
 		pettype_params.put("id", petType.getId());
 		List<Pet> pets = new ArrayList<Pet>();
 		pets = this.namedParameterJdbcTemplate.
-    			query("SELECT pets.id, name, birth_date, type_id, owner_id FROM pets WHERE type_id=:id",
-    			pettype_params,
-    			BeanPropertyRowMapper.newInstance(Pet.class));
+		  			query("SELECT pets.id, name, birth_date, type_id, owner_id, weight FROM pets WHERE type_id=:id",
+		  			pettype_params,
+		  			BeanPropertyRowMapper.newInstance(Pet.class));
 		// cascade delete pets
 		for (Pet pet : pets){
 			Map<String, Object> pet_params = new HashMap<>();

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -81,7 +81,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", petId);
         JdbcPet pet = this.namedParameterJdbcTemplate.queryForObject(
-            "SELECT id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE id=:id",
+            "SELECT id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE id=:id",
             params,
             new JdbcPetRowMapper());
 
@@ -154,7 +154,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
             Map<String, Object> params = new HashMap<>();
             params.put("id", rs.getInt("pets_id"));
             pet = JdbcVisitRepositoryImpl.this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE pets.id=:id",
+                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE pets.id=:id",
                 params,
                 new JdbcPetRowMapper());
             params.put("type_id", pet.getTypeId());

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -157,6 +157,7 @@ public class OwnerRestController implements OwnersApi {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());
                 currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+                currentPet.setWeight(petFieldsDto.getWeight());
                 this.clinicService.savePet(currentPet);
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -80,6 +80,7 @@ public class PetRestController implements PetsApi {
         currentPet.setBirthDate(petDto.getBirthDate());
         currentPet.setName(petDto.getName());
         currentPet.setType(petMapper.toPetType(petDto.getType()));
+        currentPet.setWeight(petDto.getWeight());
         this.clinicService.savePet(currentPet);
         return new ResponseEntity<>(petMapper.toPetDto(currentPet), HttpStatus.NO_CONTENT);
     }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -44,20 +44,20 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) VALUES
 ('Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
 -- Insert Pets
-INSERT INTO pets (name, birth_date, type_id, owner_id) VALUES 
-('Leo', '2010-09-07', 1, 1),
-('Basil', '2012-08-06', 6, 2),
-('Rosy', '2011-04-17', 2, 3),
-('Jewel', '2010-03-07', 2, 3),
-('Iggy', '2010-11-30', 3, 4),
-('George', '2010-01-20', 4, 5),
-('Samantha', '2012-09-04', 1, 6),
-('Max', '2012-09-04', 1, 6),
-('Lucky', '2011-08-06', 5, 7),
-('Mulligan', '2007-02-24', 2, 8),
-('Freddy', '2010-03-09', 5, 9),
-('Lucky', '2010-06-24', 2, 10),
-('Sly', '2012-06-08', 1, 10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) VALUES
+('Leo', '2010-09-07', 1, 1, 4.5),
+('Basil', '2012-08-06', 6, 2, 0.8),
+('Rosy', '2011-04-17', 2, 3, 12.3),
+('Jewel', '2010-03-07', 2, 3, NULL),
+('Iggy', '2010-11-30', 3, 4, 2.1),
+('George', '2010-01-20', 4, 5, 1.5),
+('Samantha', '2012-09-04', 1, 6, 3.8),
+('Max', '2012-09-04', 1, 6, 4.2),
+('Lucky', '2011-08-06', 5, 7, NULL),
+('Mulligan', '2007-02-24', 2, 8, 18.9),
+('Freddy', '2010-03-09', 5, 9, 0.4),
+('Lucky', '2010-06-24', 2, 10, 14.6),
+('Sly', '2012-06-08', 1, 10, 5.1);
 
 -- Insert Visits
 INSERT INTO visits (pet_id, visit_date, description) VALUES 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE NOT NULL,
   type_id INTEGER NOT NULL,
   owner_id INTEGER NOT NULL,
+  weight DECIMAL(5,2),
   FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE,
   FOREIGN KEY (type_id) REFERENCES types(id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -33,19 +33,19 @@ INSERT IGNORE INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madi
 INSERT IGNORE INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT IGNORE INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1);
-INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2);
-INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3);
-INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3);
-INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4);
-INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5);
-INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7);
-INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8);
-INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9);
-INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10);
-INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10);
+INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1, 4.5);
+INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2, 0.8);
+INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3, 12.3);
+INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3, NULL);
+INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4, 2.1);
+INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5, 1.5);
+INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6, 3.8);
+INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6, 4.2);
+INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7, NULL);
+INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8, 18.9);
+INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9, 0.4);
+INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10, 14.6);
+INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10, 5.1);
 
 INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot');
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot');

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE,
   type_id INT(4) UNSIGNED NOT NULL,
   owner_id INT(4) UNSIGNED NOT NULL,
+  weight DECIMAL(5,2),
   INDEX(name),
   FOREIGN KEY (owner_id) REFERENCES owners(id),
   FOREIGN KEY (type_id) REFERENCES types(id)

--- a/src/main/resources/db/postgres/data.sql
+++ b/src/main/resources/db/postgres/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Mar
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=9);
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=10);
 
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Leo', '2000-09-07', 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Basil', '2002-08-06', 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Rosy', '2001-04-17', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Jewel', '2000-03-07', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Iggy', '2000-11-30', 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'George', '2000-01-20', 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Samantha', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Max', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '1999-08-06', 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Freddy', '2000-03-09', 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '2000-06-24', 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Sly', '2002-06-08', 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Leo', '2000-09-07', 1, 1, 4.5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Basil', '2002-08-06', 6, 2, 0.8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Rosy', '2001-04-17', 2, 3, 12.3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Jewel', '2000-03-07', 2, 3, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Iggy', '2000-11-30', 3, 4, 2.1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'George', '2000-01-20', 4, 5, 1.5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Samantha', '1995-09-04', 1, 6, 3.8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Max', '1995-09-04', 1, 6, 4.2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '1999-08-06', 5, 7, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Mulligan', '1997-02-24', 2, 8, 18.9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Freddy', '2000-03-09', 5, 9, 0.4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '2000-06-24', 2, 10, 14.6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Sly', '2002-06-08', 1, 10, 5.1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
 
 INSERT INTO visits (pet_id, visit_date, description) SELECT 7, '2010-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=1);
 INSERT INTO visits (pet_id, visit_date, description) SELECT 8, '2011-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=2);

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS pets (
                                     name       TEXT,
                                     birth_date DATE,
                                     type_id    INT NOT NULL REFERENCES types (id),
-                                    owner_id   INT REFERENCES owners (id)
+                                    owner_id   INT REFERENCES owners (id),
+                                    weight     DECIMAL(5,2)
 );
 CREATE INDEX ON pets (name);
 CREATE INDEX ON pets (owner_id);

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1955,6 +1955,14 @@ components:
           example: '2010-09-07'
         type:
           $ref: '#/components/schemas/PetType'
+        weight:
+          title: Weight
+          description: The weight of the pet in kilograms.
+          type: number
+          format: decimal
+          minimum: 0
+          maximum: 999.99
+          example: 4.5
       required:
         - name
         - birthDate

--- a/src/test/java/org/springframework/samples/petclinic/integration/PetWeightIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/integration/PetWeightIntegrationTests.java
@@ -1,0 +1,496 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.samples.petclinic.PetClinicApplication;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = PetClinicApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestPropertySource(properties = {
+    "petclinic.security.enable=false"
+})
+@Transactional
+class PetWeightIntegrationTests {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ClinicService clinicService;
+
+    private ObjectMapper objectMapper;
+    private HttpHeaders headers;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/petclinic/api";
+
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // Set up headers without authentication since security is disabled
+        headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void testCompleteWeightWorkflowThroughRestApi() throws Exception {
+        // 1. Create a new pet with weight through REST API
+        PetDto newPet = createTestPetDto();
+        newPet.setWeight(new BigDecimal("25.75"));
+
+        HttpEntity<PetDto> createRequest = new HttpEntity<>(newPet, headers);
+
+        // Create pet via REST API
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            createRequest,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        PetDto createdPet = createResponse.getBody();
+        assertNotNull(createdPet);
+        Integer petId = createdPet.getId();
+        assertNotNull(petId);
+
+        // 2. Verify pet was created with correct weight via REST API
+        HttpEntity<Void> getRequest = new HttpEntity<>(headers);
+        ResponseEntity<String> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        JsonNode petJson = objectMapper.readTree(getResponse.getBody());
+        assertEquals(25.75, petJson.get("weight").asDouble());
+        assertEquals("TestPet", petJson.get("name").asText());
+        assertEquals("dog", petJson.get("type").get("name").asText());
+
+        // 3. Update pet weight via REST API
+        createdPet.setWeight(new BigDecimal("30.25"));
+        HttpEntity<PetDto> updateRequest = new HttpEntity<>(createdPet, headers);
+
+        ResponseEntity<Void> updateResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.PUT,
+            updateRequest,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, updateResponse.getStatusCode());
+
+        // 4. Verify weight was updated via REST API
+        ResponseEntity<String> getUpdatedResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getUpdatedResponse.getStatusCode());
+        JsonNode updatedPetJson = objectMapper.readTree(getUpdatedResponse.getBody());
+        assertEquals(30.25, updatedPetJson.get("weight").asDouble());
+
+        // 5. Set weight to null via REST API
+        createdPet.setWeight(null);
+        HttpEntity<PetDto> nullWeightRequest = new HttpEntity<>(createdPet, headers);
+
+        ResponseEntity<Void> nullWeightResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.PUT,
+            nullWeightRequest,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, nullWeightResponse.getStatusCode());
+
+        // 6. Verify weight is null via REST API
+        ResponseEntity<String> getNullWeightResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getNullWeightResponse.getStatusCode());
+        JsonNode nullWeightPetJson = objectMapper.readTree(getNullWeightResponse.getBody());
+        assertTrue(nullWeightPetJson.get("weight").isNull());
+
+        // 7. Verify data persistence through service layer
+        Pet persistedPet = clinicService.findPetById(petId);
+        assertNotNull(persistedPet);
+        assertNull(persistedPet.getWeight());
+        assertEquals("TestPet", persistedPet.getName());
+    }
+
+    @Test
+    void testWeightValidationThroughRestApi() throws Exception {
+        PetDto newPet = createTestPetDto();
+
+        // Test invalid negative weight
+        newPet.setWeight(new BigDecimal("-5.00"));
+        HttpEntity<PetDto> invalidRequest = new HttpEntity<>(newPet, headers);
+
+        ResponseEntity<String> invalidResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            invalidRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, invalidResponse.getStatusCode());
+
+        // Test weight too large
+        newPet.setWeight(new BigDecimal("1000.00"));
+        HttpEntity<PetDto> largeRequest = new HttpEntity<>(newPet, headers);
+
+        ResponseEntity<String> largeResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            largeRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, largeResponse.getStatusCode());
+
+        // Test valid weight
+        newPet.setWeight(new BigDecimal("15.50"));
+        HttpEntity<PetDto> validRequest = new HttpEntity<>(newPet, headers);
+
+        ResponseEntity<PetDto> validResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            validRequest,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, validResponse.getStatusCode());
+        assertNotNull(validResponse.getBody());
+    }
+
+    @Test
+    void testWeightInOwnerPetOperations() throws Exception {
+        // Test creating pet through owner endpoint with weight
+        PetDto newPet = createTestPetDto();
+        newPet.setWeight(new BigDecimal("18.75"));
+
+        HttpEntity<PetDto> createRequest = new HttpEntity<>(newPet, headers);
+
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            createRequest,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        PetDto createdPet = createResponse.getBody();
+        assertNotNull(createdPet);
+        Integer petId = createdPet.getId();
+
+        // Test getting pet through owner endpoint includes weight
+        HttpEntity<Void> getRequest = new HttpEntity<>(headers);
+        ResponseEntity<String> getResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        JsonNode petJson = objectMapper.readTree(getResponse.getBody());
+        assertEquals(18.75, petJson.get("weight").asDouble());
+
+        // Test updating pet through owner endpoint with new weight
+        createdPet.setWeight(new BigDecimal("22.00"));
+        HttpEntity<PetDto> updateRequest = new HttpEntity<>(createdPet, headers);
+
+        ResponseEntity<Void> updateResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets/" + petId,
+            HttpMethod.PUT,
+            updateRequest,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, updateResponse.getStatusCode());
+
+        // Verify weight was updated
+        ResponseEntity<String> getUpdatedResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getUpdatedResponse.getStatusCode());
+        JsonNode updatedPetJson = objectMapper.readTree(getUpdatedResponse.getBody());
+        assertEquals(22.0, updatedPetJson.get("weight").asDouble());
+    }
+
+    @Test
+    void testWeightInAllPetsEndpoint() throws Exception {
+        // Get all pets and verify weight field is included
+        HttpEntity<Void> getRequest = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+            baseUrl + "/pets",
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        JsonNode petsArray = objectMapper.readTree(response.getBody());
+        assertTrue(petsArray.isArray());
+        assertTrue(petsArray.size() > 0);
+
+        // Check that weight field exists in response (may be null or have value)
+        JsonNode firstPet = petsArray.get(0);
+        assertTrue(firstPet.has("weight"));
+    }
+
+    @Test
+    void testSpecificEndpointWeightHandling() throws Exception {
+        // Create a test pet first
+        PetDto newPet = createTestPetDto();
+        newPet.setWeight(new BigDecimal("12.34"));
+
+        HttpEntity<PetDto> createRequest = new HttpEntity<>(newPet, headers);
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            createRequest,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        PetDto createdPet = createResponse.getBody();
+        assertNotNull(createdPet);
+        Integer petId = createdPet.getId();
+
+        // 1. Test GET /api/pets/{petId} - return weight as decimal number in JSON response
+        HttpEntity<Void> getRequest = new HttpEntity<>(headers);
+        ResponseEntity<String> getPetResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getPetResponse.getStatusCode());
+        JsonNode petJson = objectMapper.readTree(getPetResponse.getBody());
+        assertTrue(petJson.has("weight"));
+        assertEquals(12.34, petJson.get("weight").asDouble());
+
+        // 2. Test PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
+        createdPet.setWeight(new BigDecimal("56.78"));
+        HttpEntity<PetDto> updatePetRequest = new HttpEntity<>(createdPet, headers);
+        ResponseEntity<Void> updatePetResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.PUT,
+            updatePetRequest,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, updatePetResponse.getStatusCode());
+
+        // Verify the update worked
+        ResponseEntity<String> getUpdatedPetResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+        JsonNode updatedPetJson = objectMapper.readTree(getUpdatedPetResponse.getBody());
+        assertEquals(56.78, updatedPetJson.get("weight").asDouble());
+
+        // 3. Test GET /api/pets - return weight for all pets in response array
+        ResponseEntity<String> getAllPetsResponse = restTemplate.exchange(
+            baseUrl + "/pets",
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+
+        assertEquals(HttpStatus.OK, getAllPetsResponse.getStatusCode());
+        JsonNode petsArray = objectMapper.readTree(getAllPetsResponse.getBody());
+        assertTrue(petsArray.isArray());
+        assertTrue(petsArray.size() > 0);
+
+        // Find our created pet in the array and verify weight
+        boolean foundOurPet = false;
+        for (JsonNode pet : petsArray) {
+            if (pet.get("id").asInt() == petId) {
+                assertTrue(pet.has("weight"));
+                assertEquals(56.78, pet.get("weight").asDouble());
+                foundOurPet = true;
+                break;
+            }
+        }
+        assertTrue(foundOurPet, "Created pet should be found in GET /api/pets response");
+
+        // 4. Test POST /api/owners/{ownerId}/pets - accept weight when creating pets
+        PetDto anotherPet = createTestPetDto();
+        anotherPet.setName("AnotherTestPet");
+        anotherPet.setWeight(new BigDecimal("99.99"));
+
+        HttpEntity<PetDto> createAnotherRequest = new HttpEntity<>(anotherPet, headers);
+        ResponseEntity<PetDto> createAnotherResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets",
+            HttpMethod.POST,
+            createAnotherRequest,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createAnotherResponse.getStatusCode());
+        PetDto createdAnotherPet = createAnotherResponse.getBody();
+        assertNotNull(createdAnotherPet);
+        assertEquals(new BigDecimal("99.99"), createdAnotherPet.getWeight());
+
+        // 5. Test PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates
+        Integer anotherPetId = createdAnotherPet.getId();
+        createdAnotherPet.setWeight(new BigDecimal("88.88"));
+
+        HttpEntity<PetDto> updateOwnerPetRequest = new HttpEntity<>(createdAnotherPet, headers);
+        ResponseEntity<Void> updateOwnerPetResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets/" + anotherPetId,
+            HttpMethod.PUT,
+            updateOwnerPetRequest,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, updateOwnerPetResponse.getStatusCode());
+
+        // Verify the owner pet update worked
+        ResponseEntity<String> getUpdatedOwnerPetResponse = restTemplate.exchange(
+            baseUrl + "/owners/1/pets/" + anotherPetId,
+            HttpMethod.GET,
+            getRequest,
+            String.class
+        );
+        JsonNode updatedOwnerPetJson = objectMapper.readTree(getUpdatedOwnerPetResponse.getBody());
+        assertEquals(88.88, updatedOwnerPetJson.get("weight").asDouble());
+    }
+
+    @Test
+    void testWeightPersistenceAcrossServiceLayers() {
+        // Test direct service layer operations
+        Owner owner = clinicService.findOwnerById(1);
+        assertNotNull(owner);
+
+        PetType petType = clinicService.findPetTypeById(1);
+        assertNotNull(petType);
+
+        // Create pet with weight through service layer
+        Pet newPet = new Pet();
+        newPet.setName("ServiceTestPet");
+        newPet.setBirthDate(LocalDate.now().minusYears(2));
+        newPet.setType(petType);
+        newPet.setOwner(owner);
+        newPet.setWeight(new BigDecimal("12.50"));
+
+        clinicService.savePet(newPet);
+        assertNotNull(newPet.getId());
+
+        // Retrieve and verify weight persistence
+        Pet retrievedPet = clinicService.findPetById(newPet.getId());
+        assertNotNull(retrievedPet);
+        assertEquals(new BigDecimal("12.50"), retrievedPet.getWeight());
+        assertEquals("ServiceTestPet", retrievedPet.getName());
+
+        // Update weight through service layer
+        retrievedPet.setWeight(new BigDecimal("15.75"));
+        clinicService.savePet(retrievedPet);
+
+        // Verify weight update
+        Pet updatedPet = clinicService.findPetById(newPet.getId());
+        assertEquals(new BigDecimal("15.75"), updatedPet.getWeight());
+
+        // Test null weight
+        updatedPet.setWeight(null);
+        clinicService.savePet(updatedPet);
+
+        Pet nullWeightPet = clinicService.findPetById(newPet.getId());
+        assertNull(nullWeightPet.getWeight());
+    }
+
+    @Test
+    void testWeightInExistingPetsFromDatabase() {
+        // Test that existing pets from data.sql have weight values
+        Pet pet1 = clinicService.findPetById(1);
+        assertNotNull(pet1);
+        // Pet 1 (Leo) should have weight 4.5 based on our data.sql
+        assertEquals(new BigDecimal("4.50"), pet1.getWeight());
+
+        Pet pet2 = clinicService.findPetById(2);
+        assertNotNull(pet2);
+        // Pet 2 (Basil) should have weight 0.8 based on our data.sql
+        assertEquals(new BigDecimal("0.80"), pet2.getWeight());
+
+        Pet pet3 = clinicService.findPetById(4);
+        assertNotNull(pet3);
+        // Pet 4 (Jewel) should have null weight based on our data.sql
+        assertNull(pet3.getWeight());
+    }
+
+    private PetDto createTestPetDto() {
+        PetTypeDto petType = new PetTypeDto();
+        petType.setId(2);
+        petType.setName("dog");
+
+        PetDto pet = new PetDto();
+        pet.setName("TestPet");
+        pet.setBirthDate(LocalDate.now().minusYears(1));
+        pet.setType(petType);
+
+        return pet;
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -43,6 +43,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -111,13 +112,15 @@ class OwnerRestControllerTests {
         pets.add(pet.id(3)
             .name("Rosy")
             .birthDate(LocalDate.now())
-            .type(petType));
+            .type(petType)
+            .weight(new BigDecimal("12.75")));
 
         pet = new PetDto();
         pets.add(pet.id(4)
             .name("Jewel")
             .birthDate(LocalDate.now())
-            .type(petType));
+            .type(petType)
+            .weight(null));
 
         visits = new ArrayList<>();
         VisitDto visit = new VisitDto();
@@ -138,7 +141,7 @@ class OwnerRestControllerTests {
     private PetDto getTestPetWithIdAndName(final OwnerDto owner, final int id, final String name) {
         PetTypeDto petType = new PetTypeDto();
         PetDto pet = new PetDto();
-        pet.id(id).name(name).birthDate(LocalDate.now()).type(petType.id(2).name("dog")).addVisitsItem(getTestVisitForPet(pet, 1));
+        pet.id(id).name(name).birthDate(LocalDate.now()).type(petType.id(2).name("dog")).weight(new BigDecimal("15.50")).addVisitsItem(getTestVisitForPet(pet, 1));
         return pet;
     }
 
@@ -366,6 +369,54 @@ class OwnerRestControllerTests {
 
     @Test
     @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithWeightSuccess() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(999);
+        newPet.setWeight(new BigDecimal("22.50"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithNullWeightSuccess() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(999);
+        newPet.setWeight(null);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithInvalidWeightError() throws Exception {
+        PetDto newPet = pets.get(0);
+        newPet.setId(999);
+        newPet.setWeight(new BigDecimal("-5.00"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(post("/api/owners/1/pets")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
     void testCreatePetError() throws Exception {
         PetDto newPet = pets.get(0);
         newPet.setId(null);
@@ -440,6 +491,7 @@ class OwnerRestControllerTests {
         PetDto updatedPetDto = pets.get(0);
         updatedPetDto.setName("Rex");
         updatedPetDto.setBirthDate(LocalDate.of(2020, 1, 15));
+        updatedPetDto.setWeight(new BigDecimal("18.25"));
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
         mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -94,13 +95,15 @@ class PetRestControllerTests {
         pets.add(pet.id(3)
             .name("Rosy")
             .birthDate(LocalDate.now())
-            .type(petType));
+            .type(petType)
+            .weight(new BigDecimal("15.50")));
 
         pet = new PetDto();
         pets.add(pet.id(4)
             .name("Jewel")
             .birthDate(LocalDate.now())
-            .type(petType));
+            .type(petType)
+            .weight(null)); // Test null weight
     }
 
     @Test
@@ -112,7 +115,8 @@ class PetRestControllerTests {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.id").value(3))
-            .andExpect(jsonPath("$.name").value("Rosy"));
+            .andExpect(jsonPath("$.name").value("Rosy"))
+            .andExpect(jsonPath("$.weight").value(15.50));
     }
 
     @Test
@@ -137,8 +141,10 @@ class PetRestControllerTests {
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.[0].id").value(3))
             .andExpect(jsonPath("$.[0].name").value("Rosy"))
+            .andExpect(jsonPath("$.[0].weight").value(15.50))
             .andExpect(jsonPath("$.[1].id").value(4))
-            .andExpect(jsonPath("$.[1].name").value("Jewel"));
+            .andExpect(jsonPath("$.[1].name").value("Jewel"))
+            .andExpect(jsonPath("$.[1].weight").isEmpty());
     }
 
     @Test
@@ -218,5 +224,81 @@ class PetRestControllerTests {
                 .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isNotFound());
     }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithValidWeight() throws Exception {
+        given(this.clinicService.findPetById(3)).willReturn(petMapper.toPet(pets.get(0)));
+        PetDto newPet = pets.get(0);
+        newPet.setName("Rosy Updated");
+        newPet.setWeight(new BigDecimal("20.75"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithNullWeight() throws Exception {
+        given(this.clinicService.findPetById(3)).willReturn(petMapper.toPet(pets.get(0)));
+        PetDto newPet = pets.get(0);
+        newPet.setName("Rosy No Weight");
+        newPet.setWeight(null);
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithMinimumWeight() throws Exception {
+        given(this.clinicService.findPetById(3)).willReturn(petMapper.toPet(pets.get(0)));
+        PetDto newPet = pets.get(0);
+        newPet.setName("Tiny Pet");
+        newPet.setWeight(new BigDecimal("0.01"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithMaximumWeight() throws Exception {
+        given(this.clinicService.findPetById(3)).willReturn(petMapper.toPet(pets.get(0)));
+        PetDto newPet = pets.get(0);
+        newPet.setName("Giant Pet");
+        newPet.setWeight(new BigDecimal("999.99"));
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        String newPetAsJSON = mapper.writeValueAsString(newPet);
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(newPetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNoContent());
+    }
+
+    // Note: Weight validation error tests are covered in ValidatorTests
+    // since validation happens at the model level, not in the REST controller layer
+    // when using mocked services.
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
@@ -23,6 +23,7 @@ import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -137,6 +138,7 @@ abstract class AbstractClinicServiceTests {
         Collection<PetType> types = this.clinicService.findPetTypes();
         pet.setType(EntityUtils.getById(types, PetType.class, 2));
         pet.setBirthDate(LocalDate.now());
+        pet.setWeight(new BigDecimal("25.50"));
         owner6.addPet(pet);
         assertThat(owner6.getPets().size()).isEqualTo(found + 1);
 
@@ -147,6 +149,9 @@ abstract class AbstractClinicServiceTests {
         assertThat(owner6.getPets().size()).isEqualTo(found + 1);
         // checks that id has been generated
         assertThat(pet.getId()).isNotNull();
+        // checks that weight is persisted
+        Pet savedPet = this.clinicService.findPetById(pet.getId());
+        assertThat(savedPet.getWeight()).isEqualTo(new BigDecimal("25.50"));
     }
 
     @Test
@@ -499,6 +504,113 @@ abstract class AbstractClinicServiceTests {
                     actual -> actual.getName().equals(expected.getName())
                     && actual.getId().equals(expected.getId()))).isTrue();
         }
+    }
+
+    @Test
+    @Transactional
+    void shouldInsertPetWithNullWeight() {
+        Owner owner6 = this.clinicService.findOwnerById(6);
+        int found = owner6.getPets().size();
+
+        Pet pet = new Pet();
+        pet.setName("weightless");
+        Collection<PetType> types = this.clinicService.findPetTypes();
+        pet.setType(EntityUtils.getById(types, PetType.class, 1));
+        pet.setBirthDate(LocalDate.now());
+        pet.setWeight(null);
+        owner6.addPet(pet);
+
+        this.clinicService.savePet(pet);
+        this.clinicService.saveOwner(owner6);
+
+        Pet savedPet = this.clinicService.findPetById(pet.getId());
+        assertThat(savedPet.getWeight()).isNull();
+    }
+
+    @Test
+    @Transactional
+    void shouldUpdatePetWeight() throws Exception {
+        Pet pet7 = this.clinicService.findPetById(7);
+        BigDecimal oldWeight = pet7.getWeight();
+
+        BigDecimal newWeight = new BigDecimal("30.75");
+        pet7.setWeight(newWeight);
+        this.clinicService.savePet(pet7);
+
+        pet7 = this.clinicService.findPetById(7);
+        assertThat(pet7.getWeight()).isEqualTo(newWeight);
+        assertThat(pet7.getWeight()).isNotEqualTo(oldWeight);
+    }
+
+    @Test
+    @Transactional
+    void shouldUpdatePetWeightToNull() throws Exception {
+        Pet pet7 = this.clinicService.findPetById(7);
+        pet7.setWeight(null);
+        this.clinicService.savePet(pet7);
+
+        pet7 = this.clinicService.findPetById(7);
+        assertThat(pet7.getWeight()).isNull();
+    }
+
+    @Test
+    @Transactional
+    void shouldUpdatePetWeightFromNull() throws Exception {
+        Pet pet = new Pet();
+        pet.setName("testWeightUpdate");
+        Collection<PetType> types = this.clinicService.findPetTypes();
+        pet.setType(EntityUtils.getById(types, PetType.class, 1));
+        pet.setBirthDate(LocalDate.now());
+        pet.setWeight(null);
+        
+        Owner owner6 = this.clinicService.findOwnerById(6);
+        owner6.addPet(pet);
+        this.clinicService.savePet(pet);
+        this.clinicService.saveOwner(owner6);
+
+        // Verify pet was saved with null weight
+        Pet savedPet = this.clinicService.findPetById(pet.getId());
+        assertThat(savedPet.getWeight()).isNull();
+
+        // Update weight from null to a value
+        BigDecimal newWeight = new BigDecimal("12.25");
+        savedPet.setWeight(newWeight);
+        this.clinicService.savePet(savedPet);
+
+        // Verify weight was updated
+        Pet updatedPet = this.clinicService.findPetById(pet.getId());
+        assertThat(updatedPet.getWeight()).isEqualTo(newWeight);
+    }
+
+    @Test
+    void shouldFindPetWithWeight() {
+        Pet pet1 = this.clinicService.findPetById(1);
+        assertThat(pet1.getName()).isEqualTo("Leo");
+        assertThat(pet1.getWeight()).isNotNull();
+        assertThat(pet1.getWeight()).isGreaterThan(BigDecimal.ZERO);
+    }
+
+    @Test
+    void shouldFindPetWithNullWeight() {
+        Pet pet4 = this.clinicService.findPetById(4);
+        assertThat(pet4.getName()).isEqualTo("Jewel");
+        assertThat(pet4.getWeight()).isNull();
+    }
+
+    @Test
+    void shouldFindAllPetsWithWeightInformation(){
+        Collection<Pet> pets = this.clinicService.findAllPets();
+        Pet pet1 = EntityUtils.getById(pets, Pet.class, 1);
+        assertThat(pet1.getName()).isEqualTo("Leo");
+        assertThat(pet1.getWeight()).isNotNull();
+        
+        Pet pet4 = EntityUtils.getById(pets, Pet.class, 4);
+        assertThat(pet4.getName()).isEqualTo("Jewel");
+        assertThat(pet4.getWeight()).isNull();
+        
+        Pet pet3 = EntityUtils.getById(pets, Pet.class, 3);
+        assertThat(pet3.getName()).isEqualTo("Rosy");
+        assertThat(pet3.getWeight()).isNotNull();
     }
 
     void clearCache() {}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -24,9 +24,9 @@ server.port=9966
 server.servlet.context-path=/petclinic/
 spring.jpa.open-in-view=false
 
-# database init
-spring.sql.init.schema-locations=classpath*:db/hsqldb/schema.sql
-spring.sql.init.data-locations=classpath*:db/hsqldb/data.sql
+# database init - using test-specific database resources
+spring.sql.init.schema-locations=classpath:db/hsqldb/schema.sql
+spring.sql.init.data-locations=classpath:db/hsqldb/data.sql
 
 spring.messages.basename=messages/messages
 logging.level.org.springframework=INFO

--- a/src/test/resources/db/hsqldb/data.sql
+++ b/src/test/resources/db/hsqldb/data.sql
@@ -33,28 +33,27 @@ INSERT INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madison', '
 INSERT INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1, 4.5);
-INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2, 0.8);
-INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3, 12.3);
+INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1, 4.50);
+INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2, 0.80);
+INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3, 12.30);
 INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3, NULL);
-INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4, 2.1);
-INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5, 1.5);
-INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6, 3.8);
-INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6, 4.2);
-INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7, NULL);
-INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8, 18.9);
-INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9, 0.4);
-INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10, 14.6);
-INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10, 5.1);
+INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4, 2.20);
+INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5, 1.80);
+INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6, 3.90);
+INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6, 4.10);
+INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7, 0.65);
+INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8, 22.50);
+INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9, 0.45);
+INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10, 18.20);
+INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10, NULL);
 
 INSERT INTO visits VALUES (1, 7, '2013-01-01', 'rabies shot');
 INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot');
 INSERT INTO visits VALUES (3, 8, '2013-01-03', 'neutered');
 INSERT INTO visits VALUES (4, 7, '2013-01-04', 'spayed');
 
-INSERT INTO users(username, password, enabled) VALUES
-('admin', '$2a$10$ymaklWBnpBKlgdMgkjWVF.GMGyvH8aDuTK.glFOaKw712LHtRRymS', TRUE);
+INSERT INTO users VALUES ('admin','admin',TRUE);
 
-INSERT INTO roles (username, role) VALUES ('admin', 'ROLE_OWNER_ADMIN');
-INSERT INTO roles (username, role) VALUES ('admin', 'ROLE_VET_ADMIN');
-INSERT INTO roles (username, role) VALUES ('admin', 'ROLE_ADMIN');
+INSERT INTO roles VALUES (1,'admin','OWNER_ADMIN');
+INSERT INTO roles VALUES (2,'admin','VET_ADMIN');
+INSERT INTO roles VALUES (3,'admin','ADMIN');

--- a/src/test/resources/db/hsqldb/schema.sql
+++ b/src/test/resources/db/hsqldb/schema.sql
@@ -8,7 +8,6 @@ DROP TABLE owners IF EXISTS;
 DROP TABLE roles IF EXISTS;
 DROP TABLE users IF EXISTS;
 
-
 CREATE TABLE vets (
   id         INTEGER IDENTITY PRIMARY KEY,
   first_name VARCHAR(30),
@@ -74,10 +73,9 @@ CREATE  TABLE users (
 );
 
 CREATE TABLE roles (
-  id              INTEGER IDENTITY PRIMARY KEY,
-  username        VARCHAR(20) NOT NULL,
-  role            VARCHAR(20) NOT NULL
+  id INTEGER IDENTITY PRIMARY KEY,
+  username VARCHAR(20) NOT NULL,
+  role VARCHAR(20) NOT NULL
 );
 ALTER TABLE roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES users (username);
 CREATE INDEX fk_username_idx ON roles (username);
-


### PR DESCRIPTION
Creating Tasks for Evaluating AI Agents #Onboarding_issue_number
Task Description:
Objective
Add weight tracking support to the Pet entity in the Spring PetClinic REST API to enable veterinarians to monitor pet weight over time.

Requirements
 * REST API Updates: All existing Pet REST endpoints must include weight field in JSON:
    * GET /api/pets/{petId} - return weight as decimal number in JSON response
    * PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
    * GET /api/pets - return weight for all pets in response array
    * POST /api/owners/{ownerId}/pets - accept weight when creating pets
    * PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates

 * JSON Format: Weight field should be represented as:
    * Field name: weight
    * Type: number (decimal)
    * Optional: can be null for pets without recorded weight
    * Example: "weight": 15.75 or "weight": null

Acceptance Criteria
* All existing Pet REST endpoints include weight field in their JSON request/response payloads
* Weight field accepts decimal numbers and null values through REST API
* Weight field persists correctly - value set via POST/PUT can be retrieved via GET
FAIL_TO_PASS: org.springframework.samples.petclinic.service.clinicService.AbstractClinicServiceTests,org.springframework.samples.petclinic.rest.controller.PetRestControllerTests,org.springframework.samples.petclinic.rest.controller.OwnerRestControllerTests,org.springframework.samples.petclinic.integration.PetWeightIntegrationTests