### PR TITLE
Golden – the solution I implemented

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -17,9 +17,10 @@ package org.springframework.samples.petclinic.model;
 
 import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.*;
+
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -48,6 +49,10 @@ public class Pet extends NamedEntity {
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
     private Set<Visit> visits;
+       
+    @Column(name = "weight", precision = 6, scale = 2)
+    private BigDecimal weight;
+   
 
     public LocalDate getBirthDate() {
         return this.birthDate;
@@ -97,6 +102,14 @@ public class Pet extends NamedEntity {
     public void addVisit(Visit visit) {
         getVisitsInternal().add(visit);
         visit.setPet(this);
+    }
+
+     public BigDecimal getWeight() {
+         return weight;
+    }
+
+    public void setWeight(BigDecimal weight) {
+         this.weight = weight;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -115,7 +115,7 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", owner.getId());
         final List<JdbcPet> pets = this.namedParameterJdbcTemplate.query(
-            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
+            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id,  weight,  visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
             params,
             new JdbcPetVisitExtractor()
         );

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -110,7 +110,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
         } else {
             this.namedParameterJdbcTemplate.update(
                 "UPDATE pets SET name=:name, birth_date=:birth_date, type_id=:type_id, " +
-                    "owner_id=:owner_id WHERE id=:id",
+                    "owner_id=:owner_id, weight=:weight WHERE id=:id",
                 createPetParameterSource(pet));
         }
     }
@@ -124,7 +124,8 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             .addValue("name", pet.getName())
             .addValue("birth_date", pet.getBirthDate())
             .addValue("type_id", pet.getType().getId())
-            .addValue("owner_id", pet.getOwner().getId());
+            .addValue("owner_id", pet.getOwner().getId())
+            .addValue("weight", pet.getWeight());
     }
     
 	@Override
@@ -133,7 +134,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
 		Collection<Pet> pets = new ArrayList<Pet>();
 		Collection<JdbcPet> jdbcPets = new ArrayList<JdbcPet>();
 		jdbcPets = this.namedParameterJdbcTemplate
-				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets",
+				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets",
 				params,
 				new JdbcPetRowMapper());
 		Collection<PetType> petTypes = this.namedParameterJdbcTemplate.query("SELECT id, name FROM types ORDER BY name",

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
@@ -36,6 +36,8 @@ public class JdbcPetRowMapper implements RowMapper<JdbcPet> {
         pet.setBirthDate(rs.getObject("birth_date", LocalDate.class));
         pet.setTypeId(rs.getInt("type_id"));
         pet.setOwnerId(rs.getInt("owner_id"));
+        pet.setWeight(rs.getBigDecimal("weight"));
+
         return pet;
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -81,7 +81,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", petId);
         JdbcPet pet = this.namedParameterJdbcTemplate.queryForObject(
-            "SELECT id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE id=:id",
+            "SELECT id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE id=:id",
             params,
             new JdbcPetRowMapper());
 
@@ -154,7 +154,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
             Map<String, Object> params = new HashMap<>();
             params.put("id", rs.getInt("pets_id"));
             pet = JdbcVisitRepositoryImpl.this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE pets.id=:id",
+                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE pets.id=:id",
                 params,
                 new JdbcPetRowMapper());
             params.put("type_id", pet.getTypeId());

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -157,6 +157,8 @@ public class OwnerRestController implements OwnersApi {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());
                 currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+                currentPet.setWeight(petFieldsDto.getWeight());
+
                 this.clinicService.savePet(currentPet);
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -80,6 +80,7 @@ public class PetRestController implements PetsApi {
         currentPet.setBirthDate(petDto.getBirthDate());
         currentPet.setName(petDto.getName());
         currentPet.setType(petMapper.toPetType(petDto.getType()));
+        currentPet.setWeight(petDto.getWeight());
         this.clinicService.savePet(currentPet);
         return new ResponseEntity<>(petMapper.toPetDto(currentPet), HttpStatus.NO_CONTENT);
     }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -44,20 +44,20 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) VALUES
 ('Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
 -- Insert Pets
-INSERT INTO pets (name, birth_date, type_id, owner_id) VALUES 
-('Leo', '2010-09-07', 1, 1),
-('Basil', '2012-08-06', 6, 2),
-('Rosy', '2011-04-17', 2, 3),
-('Jewel', '2010-03-07', 2, 3),
-('Iggy', '2010-11-30', 3, 4),
-('George', '2010-01-20', 4, 5),
-('Samantha', '2012-09-04', 1, 6),
-('Max', '2012-09-04', 1, 6),
-('Lucky', '2011-08-06', 5, 7),
-('Mulligan', '2007-02-24', 2, 8),
-('Freddy', '2010-03-09', 5, 9),
-('Lucky', '2010-06-24', 2, 10),
-('Sly', '2012-06-08', 1, 10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) VALUES 
+('Leo', '2010-09-07', 1, 1, 5.5),
+('Basil', '2012-08-06', 6, 2, null),
+('Rosy', '2011-04-17', 2, 3, null),
+('Jewel', '2010-03-07', 2, 3, null),
+('Iggy', '2010-11-30', 3, 4, null),
+('George', '2010-01-20', 4, 5, null),
+('Samantha', '2012-09-04', 1, 6, null),
+('Max', '2012-09-04', 1, 6, null),
+('Lucky', '2011-08-06', 5, 7, null),
+('Mulligan', '2007-02-24', 2, 8, null),
+('Freddy', '2010-03-09', 5, 9, null),
+('Lucky', '2010-06-24', 2, 10, null),
+('Sly', '2012-06-08', 1, 10, null);
 
 -- Insert Visits
 INSERT INTO visits (pet_id, visit_date, description) VALUES 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE NOT NULL,
   type_id INTEGER NOT NULL,
   owner_id INTEGER NOT NULL,
+  weight DECIMAL(6,2),
   FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE,
   FOREIGN KEY (type_id) REFERENCES types(id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madison', '
 INSERT INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1);
-INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2);
-INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3);
-INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3);
-INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4);
-INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5);
-INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7);
-INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8);
-INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9);
-INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10);
-INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10);
+INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1, 5.5);
+INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2, null);
+INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3, null);
+INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3, null);
+INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4, null);
+INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5, null);
+INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6, null);
+INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6, null);
+INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7, null);
+INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8, null);
+INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9, null);
+INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10, null);
+INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10, null);
 
 INSERT INTO visits VALUES (1, 7, '2013-01-01', 'rabies shot');
 INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot');

--- a/src/main/resources/db/hsqldb/schema.sql
+++ b/src/main/resources/db/hsqldb/schema.sql
@@ -50,7 +50,8 @@ CREATE TABLE pets (
   name       VARCHAR(30),
   birth_date DATE,
   type_id    INTEGER NOT NULL,
-  owner_id   INTEGER NOT NULL
+  owner_id   INTEGER NOT NULL,
+  weight DECIMAL(6,2)
 );
 ALTER TABLE pets ADD CONSTRAINT fk_pets_owners FOREIGN KEY (owner_id) REFERENCES owners (id);
 ALTER TABLE pets ADD CONSTRAINT fk_pets_types FOREIGN KEY (type_id) REFERENCES types (id);

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -33,19 +33,19 @@ INSERT IGNORE INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madi
 INSERT IGNORE INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT IGNORE INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1);
-INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2);
-INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3);
-INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3);
-INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4);
-INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5);
-INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7);
-INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8);
-INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9);
-INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10);
-INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10);
+INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1, 5.5);
+INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2, null);
+INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3, null);
+INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3, null);
+INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4, null);
+INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5, null);
+INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6,null);
+INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6, null);
+INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7, null);
+INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8, null);
+INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9,null);
+INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10, null);
+INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10, null);
 
 INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot');
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot');

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE,
   type_id INT(4) UNSIGNED NOT NULL,
   owner_id INT(4) UNSIGNED NOT NULL,
+  weight DECIMAL(6,2),
   INDEX(name),
   FOREIGN KEY (owner_id) REFERENCES owners(id),
   FOREIGN KEY (type_id) REFERENCES types(id)

--- a/src/main/resources/db/postgres/data.sql
+++ b/src/main/resources/db/postgres/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Mar
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=9);
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=10);
 
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Leo', '2000-09-07', 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Basil', '2002-08-06', 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Rosy', '2001-04-17', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Jewel', '2000-03-07', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Iggy', '2000-11-30', 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'George', '2000-01-20', 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Samantha', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Max', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '1999-08-06', 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Freddy', '2000-03-09', 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '2000-06-24', 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Sly', '2002-06-08', 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Leo', '2000-09-07', 1, 1, 5.5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Basil', '2002-08-06', 6, 2, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Rosy', '2001-04-17', 2, 3, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Jewel', '2000-03-07', 2, 3, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Iggy', '2000-11-30', 3, 4, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'George', '2000-01-20', 4, 5, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Samantha', '1995-09-04', 1, 6, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Max', '1995-09-04', 1, 6, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '1999-08-06', 5, 7, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Mulligan', '1997-02-24', 2, 8, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Freddy', '2000-03-09', 5, 9, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '2000-06-24', 2, 10, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Sly', '2002-06-08', 1, 10, null WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
 
 INSERT INTO visits (pet_id, visit_date, description) SELECT 7, '2010-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=1);
 INSERT INTO visits (pet_id, visit_date, description) SELECT 8, '2011-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=2);

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS pets (
                                     name       TEXT,
                                     birth_date DATE,
                                     type_id    INT NOT NULL REFERENCES types (id),
-                                    owner_id   INT REFERENCES owners (id)
+                                    owner_id   INT REFERENCES owners (id),
+                                    weight  NUMERIC(6,2)
 );
 CREATE INDEX ON pets (name);
 CREATE INDEX ON pets (owner_id);

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1953,6 +1953,14 @@ components:
           type: string
           format: date
           example: '2010-09-07'
+        weight:
+          title: Weight
+          description: The weight of the pet.
+          type: number
+          format: decimal
+          minimum: 0.0
+          maximum: 999.99
+          example: 5.5
         type:
           $ref: '#/components/schemas/PetType'
       required:

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
@@ -23,6 +23,7 @@ import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
@@ -499,6 +500,35 @@ abstract class AbstractClinicServiceTests {
                     actual -> actual.getName().equals(expected.getName())
                     && actual.getId().equals(expected.getId()))).isTrue();
         }
+    }
+    @Test
+    void shouldFindPetWithWeight() {
+        Pet pet1 = this.clinicService.findPetById(1);
+        assertThat(pet1.getName()).isEqualTo("Leo");
+        assertThat(pet1.getWeight()).isNotNull();
+        assertThat(pet1.getWeight()).isGreaterThan(BigDecimal.ZERO);
+    }
+    @Test
+    void shouldFindPetWithNullWeight() {
+        Pet pet4 = this.clinicService.findPetById(4);
+        assertThat(pet4.getName()).isEqualTo("Jewel");
+        assertThat(pet4.getWeight()).isNull();
+    }
+
+    @Test
+    void shouldFindAllPetsWithWeightInformation(){
+        Collection<Pet> pets = this.clinicService.findAllPets();
+        Pet pet1 = EntityUtils.getById(pets, Pet.class, 1);
+        assertThat(pet1.getName()).isEqualTo("Leo");
+        assertThat(pet1.getWeight()).isNotNull();
+
+        Pet pet4 = EntityUtils.getById(pets, Pet.class, 4);
+        assertThat(pet4.getName()).isEqualTo("Jewel");
+        assertThat(pet4.getWeight()).isNull();
+
+        Pet pet3 = EntityUtils.getById(pets, Pet.class, 3);
+        assertThat(pet3.getName()).isEqualTo("Rosy");
+        assertThat(pet3.getWeight()).isNull();
     }
 
     void clearCache() {}


### PR DESCRIPTION
Task Description:

Objective
Add weight tracking support to the Pet entity in the Spring PetClinic REST API to enable veterinarians to monitor pet weight over time.

Requirements

REST API Updates: All existing Pet REST endpoints must include weight field in JSON:

GET /api/pets/{petId} - return weight as decimal number in JSON response
PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
GET /api/pets - return weight for all pets in response array
POST /api/owners/{ownerId}/pets - accept weight when creating pets
PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates
JSON Format: Weight field should be represented as:

Field name: weight
Type: number (decimal)
Optional: can be null for pets without recorded weight
Example: "weight": 15.75 or "weight": null
Acceptance Criteria

All existing Pet REST endpoints include weight field in their JSON request/response payloads
Weight field accepts decimal numbers and null values through REST API
Weight field persists correctly - value set via POST/PUT can be retrieved via GET

FAIL_TO_PASS: 
org.springframework.samples.petclinic.rest.controller.OwnerRestControllerTests, org.springframework.samples.petclinic.rest.controller.PetRestControllerTests, 