### PR TITLE
Onboarding: Weight Tracking [golden]

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -17,9 +17,9 @@ package org.springframework.samples.petclinic.model;
 
 import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -48,6 +48,9 @@ public class Pet extends NamedEntity {
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
     private Set<Visit> visits;
+
+    @Column(name = "weight", precision = 5, scale = 2)
+    private BigDecimal weight;
 
     public LocalDate getBirthDate() {
         return this.birthDate;
@@ -97,6 +100,14 @@ public class Pet extends NamedEntity {
     public void addVisit(Visit visit) {
         getVisitsInternal().add(visit);
         visit.setPet(this);
+    }
+
+    public BigDecimal getWeight() {
+        return this.weight;
+    }
+
+    public void setWeight(BigDecimal weight) {
+        this.weight = weight;
     }
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -115,7 +115,7 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", owner.getId());
         final List<JdbcPet> pets = this.namedParameterJdbcTemplate.query(
-            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
+            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
             params,
             new JdbcPetVisitExtractor()
         );

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -110,7 +110,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
         } else {
             this.namedParameterJdbcTemplate.update(
                 "UPDATE pets SET name=:name, birth_date=:birth_date, type_id=:type_id, " +
-                    "owner_id=:owner_id WHERE id=:id",
+                    "owner_id=:owner_id, weight=:weight WHERE id=:id",
                 createPetParameterSource(pet));
         }
     }
@@ -124,7 +124,8 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             .addValue("name", pet.getName())
             .addValue("birth_date", pet.getBirthDate())
             .addValue("type_id", pet.getType().getId())
-            .addValue("owner_id", pet.getOwner().getId());
+            .addValue("owner_id", pet.getOwner().getId())
+            .addValue("weight", pet.getWeight());
     }
     
 	@Override
@@ -133,7 +134,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
 		Collection<Pet> pets = new ArrayList<Pet>();
 		Collection<JdbcPet> jdbcPets = new ArrayList<JdbcPet>();
 		jdbcPets = this.namedParameterJdbcTemplate
-				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets",
+				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets",
 				params,
 				new JdbcPetRowMapper());
 		Collection<PetType> petTypes = this.namedParameterJdbcTemplate.query("SELECT id, name FROM types ORDER BY name",

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
@@ -17,10 +17,10 @@ package org.springframework.samples.petclinic.repository.jdbc;
 
 import org.springframework.jdbc.core.RowMapper;
 
+import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
-import java.util.Date;
 
 /**
  * {@link RowMapper} implementation mapping data from a {@link ResultSet} to the corresponding properties
@@ -36,6 +36,12 @@ public class JdbcPetRowMapper implements RowMapper<JdbcPet> {
         pet.setBirthDate(rs.getObject("birth_date", LocalDate.class));
         pet.setTypeId(rs.getInt("type_id"));
         pet.setOwnerId(rs.getInt("owner_id"));
+        BigDecimal weight = rs.getBigDecimal("weight");
+        if (!rs.wasNull()) {
+            pet.setWeight(weight);
+        } else {
+            pet.setWeight(null);
+        }
         return pet;
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
@@ -119,7 +119,7 @@ public class JdbcPetTypeRepositoryImpl implements PetTypeRepository {
 		pettype_params.put("id", petType.getId());
 		List<Pet> pets = new ArrayList<Pet>();
 		pets = this.namedParameterJdbcTemplate.
-    			query("SELECT pets.id, name, birth_date, type_id, owner_id FROM pets WHERE type_id=:id",
+    			query("SELECT pets.id, name, birth_date, type_id, owner_id, weight FROM pets WHERE type_id=:id",
     			pettype_params,
     			BeanPropertyRowMapper.newInstance(Pet.class));
 		// cascade delete pets

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -81,7 +81,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", petId);
         JdbcPet pet = this.namedParameterJdbcTemplate.queryForObject(
-            "SELECT id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE id=:id",
+            "SELECT id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE id=:id",
             params,
             new JdbcPetRowMapper());
 
@@ -154,7 +154,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
             Map<String, Object> params = new HashMap<>();
             params.put("id", rs.getInt("pets_id"));
             pet = JdbcVisitRepositoryImpl.this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE pets.id=:id",
+                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, weight FROM pets WHERE pets.id=:id",
                 params,
                 new JdbcPetRowMapper());
             params.put("type_id", pet.getTypeId());

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -157,6 +157,7 @@ public class OwnerRestController implements OwnersApi {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());
                 currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+                currentPet.setWeight(petFieldsDto.getWeight());
                 this.clinicService.savePet(currentPet);
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -80,6 +80,7 @@ public class PetRestController implements PetsApi {
         currentPet.setBirthDate(petDto.getBirthDate());
         currentPet.setName(petDto.getName());
         currentPet.setType(petMapper.toPetType(petDto.getType()));
+        currentPet.setWeight(petDto.getWeight());
         this.clinicService.savePet(currentPet);
         return new ResponseEntity<>(petMapper.toPetDto(currentPet), HttpStatus.NO_CONTENT);
     }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -44,20 +44,20 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) VALUES
 ('Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
 -- Insert Pets
-INSERT INTO pets (name, birth_date, type_id, owner_id) VALUES 
-('Leo', '2010-09-07', 1, 1),
-('Basil', '2012-08-06', 6, 2),
-('Rosy', '2011-04-17', 2, 3),
-('Jewel', '2010-03-07', 2, 3),
-('Iggy', '2010-11-30', 3, 4),
-('George', '2010-01-20', 4, 5),
-('Samantha', '2012-09-04', 1, 6),
-('Max', '2012-09-04', 1, 6),
-('Lucky', '2011-08-06', 5, 7),
-('Mulligan', '2007-02-24', 2, 8),
-('Freddy', '2010-03-09', 5, 9),
-('Lucky', '2010-06-24', 2, 10),
-('Sly', '2012-06-08', 1, 10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) VALUES 
+('Leo', '2010-09-07', 1, 1, NULL),
+('Basil', '2012-08-06', 6, 2, NULL),
+('Rosy', '2011-04-17', 2, 3, NULL),
+('Jewel', '2010-03-07', 2, 3, NULL),
+('Iggy', '2010-11-30', 3, 4, NULL),
+('George', '2010-01-20', 4, 5, NULL),
+('Samantha', '2012-09-04', 1, 6, NULL),
+('Max', '2012-09-04', 1, 6, NULL),
+('Lucky', '2011-08-06', 5, 7, NULL),
+('Mulligan', '2007-02-24', 2, 8, NULL),
+('Freddy', '2010-03-09', 5, 9, NULL),
+('Lucky', '2010-06-24', 2, 10, NULL),
+('Sly', '2012-06-08', 1, 10, NULL);
 
 -- Insert Visits
 INSERT INTO visits (pet_id, visit_date, description) VALUES 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE NOT NULL,
   type_id INTEGER NOT NULL,
   owner_id INTEGER NOT NULL,
+  weight DECIMAL(5,2),
   FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE,
   FOREIGN KEY (type_id) REFERENCES types(id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madison', '
 INSERT INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1);
-INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2);
-INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3);
-INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3);
-INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4);
-INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5);
-INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7);
-INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8);
-INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9);
-INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10);
-INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10);
+INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1, NULL);
+INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2, NULL);
+INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3, NULL);
+INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3, NULL);
+INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4, NULL);
+INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5, NULL);
+INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6, NULL);
+INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6, NULL);
+INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7, NULL);
+INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8, NULL);
+INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9, NULL);
+INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10, NULL);
+INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10, NULL);
 
 INSERT INTO visits VALUES (1, 7, '2013-01-01', 'rabies shot');
 INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot');

--- a/src/main/resources/db/hsqldb/schema.sql
+++ b/src/main/resources/db/hsqldb/schema.sql
@@ -50,7 +50,8 @@ CREATE TABLE pets (
   name       VARCHAR(30),
   birth_date DATE,
   type_id    INTEGER NOT NULL,
-  owner_id   INTEGER NOT NULL
+  owner_id   INTEGER NOT NULL,
+  weight     DECIMAL(5,2)
 );
 ALTER TABLE pets ADD CONSTRAINT fk_pets_owners FOREIGN KEY (owner_id) REFERENCES owners (id);
 ALTER TABLE pets ADD CONSTRAINT fk_pets_types FOREIGN KEY (type_id) REFERENCES types (id);

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -33,19 +33,19 @@ INSERT IGNORE INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madi
 INSERT IGNORE INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT IGNORE INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1);
-INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2);
-INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3);
-INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3);
-INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4);
-INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5);
-INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7);
-INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8);
-INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9);
-INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10);
-INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10);
+INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1, NULL);
+INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2, NULL);
+INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3, NULL);
+INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3, NULL);
+INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4, NULL);
+INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5, NULL);
+INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6, NULL);
+INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6, NULL);
+INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7, NULL);
+INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8, NULL);
+INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9, NULL);
+INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10, NULL);
+INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10, NULL);
 
 INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot');
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot');

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE,
   type_id INT(4) UNSIGNED NOT NULL,
   owner_id INT(4) UNSIGNED NOT NULL,
+  weight DECIMAL(5,2),
   INDEX(name),
   FOREIGN KEY (owner_id) REFERENCES owners(id),
   FOREIGN KEY (type_id) REFERENCES types(id)

--- a/src/main/resources/db/postgres/data.sql
+++ b/src/main/resources/db/postgres/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Mar
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=9);
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=10);
 
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Leo', '2000-09-07', 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Basil', '2002-08-06', 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Rosy', '2001-04-17', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Jewel', '2000-03-07', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Iggy', '2000-11-30', 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'George', '2000-01-20', 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Samantha', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Max', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '1999-08-06', 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Freddy', '2000-03-09', 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '2000-06-24', 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Sly', '2002-06-08', 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Leo', '2000-09-07', 1, 1, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Basil', '2002-08-06', 6, 2, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Rosy', '2001-04-17', 2, 3, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Jewel', '2000-03-07', 2, 3, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Iggy', '2000-11-30', 3, 4, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'George', '2000-01-20', 4, 5, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Samantha', '1995-09-04', 1, 6, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Max', '1995-09-04', 1, 6, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '1999-08-06', 5, 7, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Mulligan', '1997-02-24', 2, 8, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Freddy', '2000-03-09', 5, 9, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '2000-06-24', 2, 10, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Sly', '2002-06-08', 1, 10, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
 
 INSERT INTO visits (pet_id, visit_date, description) SELECT 7, '2010-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=1);
 INSERT INTO visits (pet_id, visit_date, description) SELECT 8, '2011-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=2);

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS pets (
                                     name       TEXT,
                                     birth_date DATE,
                                     type_id    INT NOT NULL REFERENCES types (id),
-                                    owner_id   INT REFERENCES owners (id)
+                                    owner_id   INT REFERENCES owners (id),
+                                    weight     DECIMAL(5,2)
 );
 CREATE INDEX ON pets (name);
 CREATE INDEX ON pets (owner_id);

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1955,6 +1955,13 @@ components:
           example: '2010-09-07'
         type:
           $ref: '#/components/schemas/PetType'
+        weight:
+          title: Weight
+          description: The weight of the pet in decimal format.
+          type: number
+          format: decimal
+          nullable: true
+          example: 15.75
       required:
         - name
         - birthDate
@@ -1989,6 +1996,13 @@ components:
               items:
                 $ref: '#/components/schemas/Visit'
               readOnly: true
+            weight:
+              title: Weight
+              description: The weight of the pet in decimal format.
+              type: number
+              format: decimal
+              nullable: true
+              example: 15.75
           required:
             - id
             - type

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/integration/OwnerPetWeightIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/integration/OwnerPetWeightIntegrationTests.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.rest.controller.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.samples.petclinic.rest.dto.PetFieldsDto;
+import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end integration tests for Pet weight field functionality via OwnerRestController.
+ * These tests use TestRestTemplate to make actual HTTP requests to a real embedded server,
+ * validating JSON request/response handling through the full Spring MVC stack with a real database.
+ *
+ * @author Spring PetClinic Team
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"h2", "spring-data-jpa"})
+@TestPropertySource(properties = {
+    "spring.sql.init.schema-locations=classpath*:db/h2/schema.sql",
+    "spring.sql.init.data-locations=classpath*:db/h2/data.sql",
+    "petclinic.security.enable=false",
+    "server.servlet.context-path="
+})
+class OwnerPetWeightIntegrationTests {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String baseUrl;
+
+    private Integer ownerId;
+    private Integer petTypeId;
+    private String petTypeName;
+    private Integer petId;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/api";
+        // Use seeded data.sql owner/type to avoid model/repository usage
+        ownerId = 1;
+        petTypeId = 1;
+        petTypeName = "dog";
+
+        // Seed a baseline pet via API to reuse in tests
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Buddy");
+        petFields.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("25.75"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        petId = response.getBody().getId();
+        assertNotNull(petId, "Pet ID should be assigned");
+    }
+
+    @Test
+    void testCreatePetWithWeight() throws Exception {
+        // POST /api/owners/{ownerId}/pets - 201 CREATED with weight
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Rex");
+        petFields.setBirthDate(LocalDate.of(2022, 6, 1));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("15.50"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("Rex", response.getBody().getName());
+        assertEquals(new BigDecimal("15.50"), response.getBody().getWeight());
+    }
+
+    @Test
+    void testCreatePetWithNullWeight() throws Exception {
+        // POST /api/owners/{ownerId}/pets - 201 CREATED with null weight
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Luna");
+        petFields.setBirthDate(LocalDate.of(2023, 1, 1));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals("Luna", response.getBody().getName());
+        assertNull(response.getBody().getWeight());
+    }
+
+    @Test
+    void testUpdateOwnersPetWithWeight() throws Exception {
+        // PUT /api/owners/{ownerId}/pets/{petId} - 204 NO_CONTENT with weight
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Buddy");
+        petFields.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("27.00"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets/" + petId,
+            HttpMethod.PUT,
+            entity,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        // Verify weight was updated
+        HttpHeaders getHeaders = new HttpHeaders();
+        getHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> getEntity = new HttpEntity<>(getHeaders);
+
+        ResponseEntity<PetDto> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        assertNotNull(getResponse.getBody());
+        assertEquals(new BigDecimal("27.00"), getResponse.getBody().getWeight());
+    }
+
+    @Test
+    void testUpdateOwnersPetWithNullWeight() throws Exception {
+        // PUT /api/owners/{ownerId}/pets/{petId} - 204 NO_CONTENT with null weight
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Buddy");
+        petFields.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets/" + petId,
+            HttpMethod.PUT,
+            entity,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        // Verify weight was set to null
+        HttpHeaders getHeaders = new HttpHeaders();
+        getHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> getEntity = new HttpEntity<>(getHeaders);
+
+        ResponseEntity<PetDto> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        assertNotNull(getResponse.getBody());
+        assertNull(getResponse.getBody().getWeight());
+    }
+
+    @Test
+    void testGetOwnersPetWithWeight() throws Exception {
+        // GET /api/owners/{ownerId}/pets/{petId} - 200 OK with weight
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets/" + petId,
+            HttpMethod.GET,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(petId, response.getBody().getId());
+        assertEquals("Buddy", response.getBody().getName());
+        assertEquals(new BigDecimal("25.75"), response.getBody().getWeight());
+    }
+
+    @Test
+    void testWeightPersistence() throws Exception {
+        // POST /api/owners/{ownerId}/pets - Test that weight value set via POST can be retrieved via GET
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Charlie");
+        petFields.setBirthDate(LocalDate.of(2021, 3, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("22.75"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        assertNotNull(createResponse.getBody());
+        Integer createdPetId = createResponse.getBody().getId();
+
+        // Retrieve the pet and verify weight persists
+        HttpHeaders getHeaders = new HttpHeaders();
+        getHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> getEntity = new HttpEntity<>(getHeaders);
+
+        ResponseEntity<PetDto> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + createdPetId,
+            HttpMethod.GET,
+            getEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        assertNotNull(getResponse.getBody());
+        assertEquals(createdPetId, getResponse.getBody().getId());
+        assertEquals("Charlie", getResponse.getBody().getName());
+        assertEquals(new BigDecimal("22.75"), getResponse.getBody().getWeight());
+    }
+
+    @Test
+    void testCreatePetWithInvalidJson() {
+        // POST /api/owners/{ownerId}/pets - 400/500 when JSON is malformed (500 is acceptable for parsing errors)
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        String invalidJson = "{ \"name\": \"Test\", \"birthDate\": \"2022-06-01\", \"weight\": \"invalid\" }";
+        HttpEntity<String> entity = new HttpEntity<>(invalidJson, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            String.class
+        );
+
+        // Invalid JSON can result in either 400 or 500 depending on when parsing fails
+        assertTrue(response.getStatusCode() == HttpStatus.BAD_REQUEST || 
+                   response.getStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}
+

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/integration/PetWeightIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/integration/PetWeightIntegrationTests.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.rest.controller.integration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.samples.petclinic.rest.dto.PetFieldsDto;
+import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end integration tests for Pet weight field functionality via PetRestController.
+ * These tests use TestRestTemplate to make actual HTTP requests to a real embedded server,
+ * validating JSON request/response handling through the full Spring MVC stack with a real database.
+ *
+ * @author Spring PetClinic Team
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"h2", "spring-data-jpa"})
+@TestPropertySource(properties = {
+    "spring.sql.init.schema-locations=classpath*:db/h2/schema.sql",
+    "spring.sql.init.data-locations=classpath*:db/h2/data.sql",
+    "petclinic.security.enable=false",
+    "server.servlet.context-path="
+})
+class PetWeightIntegrationTests {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private String baseUrl;
+
+    private Integer ownerId;
+    private Integer petTypeId;
+    private String petTypeName;
+    private Integer petId;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/api";
+        // Use seeded data.sql owner/type to avoid model/repository usage
+        ownerId = 1;
+        petTypeId = 1;
+        petTypeName = "dog";
+
+        // Create a baseline pet via API to obtain petId for subsequent tests
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Buddy");
+        petFields.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("25.75"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> entity = new HttpEntity<>(petFields, headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        petId = response.getBody().getId();
+        assertNotNull(petId, "Pet ID should be assigned");
+    }
+
+
+    @Test
+    void testGetPetWithWeight() {
+        // GET /api/pets/{petId} - 200 OK with weight
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(petId, response.getBody().getId());
+        assertEquals("Buddy", response.getBody().getName());
+        assertEquals(new BigDecimal("25.75"), response.getBody().getWeight());
+    }
+
+    @Test
+    void testGetPetWithNullWeight() throws Exception {
+        // Create a pet with null weight via API, then GET
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Fluffy");
+        petFields.setBirthDate(LocalDate.of(2021, 5, 10));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(null);
+
+        HttpHeaders createHeaders = new HttpHeaders();
+        createHeaders.setContentType(MediaType.APPLICATION_JSON);
+        createHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> createEntity = new HttpEntity<>(petFields, createHeaders);
+
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            createEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        assertNotNull(createResponse.getBody());
+        Integer createdPetId = createResponse.getBody().getId();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<PetDto> response = restTemplate.exchange(
+            baseUrl + "/pets/" + createdPetId,
+            HttpMethod.GET,
+            entity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertEquals(createdPetId, response.getBody().getId());
+        assertEquals("Fluffy", response.getBody().getName());
+        assertNull(response.getBody().getWeight());
+    }
+
+    @Test
+    void testGetAllPetsWithWeight() throws Exception {
+        // Create an additional pet via API, then GET all
+        PetFieldsDto petFields = new PetFieldsDto();
+        petFields.setName("Max");
+        petFields.setBirthDate(LocalDate.of(2019, 3, 20));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petFields.setType(typeDto);
+        petFields.setWeight(new BigDecimal("30.50"));
+
+        HttpHeaders createHeaders = new HttpHeaders();
+        createHeaders.setContentType(MediaType.APPLICATION_JSON);
+        createHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetFieldsDto> createEntity = new HttpEntity<>(petFields, createHeaders);
+
+        ResponseEntity<PetDto> createResponse = restTemplate.exchange(
+            baseUrl + "/owners/" + ownerId + "/pets",
+            HttpMethod.POST,
+            createEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.CREATED, createResponse.getStatusCode());
+        assertNotNull(createResponse.getBody());
+        Integer pet2Id = createResponse.getBody().getId();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<PetDto[]> response = restTemplate.exchange(
+            baseUrl + "/pets",
+            HttpMethod.GET,
+            entity,
+            PetDto[].class
+        );
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+        
+        PetDto pet1 = java.util.Arrays.stream(response.getBody())
+            .filter(p -> p.getId().equals(petId))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(pet1);
+        assertEquals(new BigDecimal("25.75"), pet1.getWeight());
+        
+        PetDto pet2Dto = java.util.Arrays.stream(response.getBody())
+            .filter(p -> p.getId().equals(pet2Id))
+            .findFirst()
+            .orElse(null);
+        assertNotNull(pet2Dto);
+        assertEquals(new BigDecimal("30.50"), pet2Dto.getWeight());
+    }
+
+    @Test
+    void testUpdatePetWithWeight() throws Exception {
+        // PUT /api/pets/{petId} - 204 NO_CONTENT with weight
+        PetDto petUpdate = new PetDto();
+        petUpdate.setId(petId);
+        petUpdate.setName("Buddy Updated");
+        petUpdate.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petUpdate.setType(typeDto);
+        petUpdate.setWeight(new BigDecimal("28.25"));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetDto> entity = new HttpEntity<>(petUpdate, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.PUT,
+            entity,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        // Verify weight was updated
+        HttpHeaders getHeaders = new HttpHeaders();
+        getHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> getEntity = new HttpEntity<>(getHeaders);
+
+        ResponseEntity<PetDto> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        assertNotNull(getResponse.getBody());
+        assertEquals(new BigDecimal("28.25"), getResponse.getBody().getWeight());
+        assertEquals("Buddy Updated", getResponse.getBody().getName());
+    }
+
+    @Test
+    void testUpdatePetWithNullWeight() throws Exception {
+        // PUT /api/pets/{petId} - 204 NO_CONTENT with null weight
+        PetDto petUpdate = new PetDto();
+        petUpdate.setId(petId);
+        petUpdate.setName("Buddy");
+        petUpdate.setBirthDate(LocalDate.of(2020, 1, 15));
+        PetTypeDto typeDto = new PetTypeDto();
+        typeDto.setId(petTypeId);
+        typeDto.setName(petTypeName);
+        petUpdate.setType(typeDto);
+        petUpdate.setWeight(null);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<PetDto> entity = new HttpEntity<>(petUpdate, headers);
+
+        ResponseEntity<Void> response = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.PUT,
+            entity,
+            Void.class
+        );
+
+        assertEquals(HttpStatus.NO_CONTENT, response.getStatusCode());
+
+        // Verify weight was set to null
+        HttpHeaders getHeaders = new HttpHeaders();
+        getHeaders.setAccept(java.util.Collections.singletonList(MediaType.APPLICATION_JSON));
+        HttpEntity<String> getEntity = new HttpEntity<>(getHeaders);
+
+        ResponseEntity<PetDto> getResponse = restTemplate.exchange(
+            baseUrl + "/pets/" + petId,
+            HttpMethod.GET,
+            getEntity,
+            PetDto.class
+        );
+
+        assertEquals(HttpStatus.OK, getResponse.getStatusCode());
+        assertNotNull(getResponse.getBody());
+        assertNull(getResponse.getBody().getWeight());
+    }
+
+}


### PR DESCRIPTION
## Objective
Add weight tracking support to the Pet entity in the Spring PetClinic REST API to enable veterinarians to monitor pet weight over time.

## Requirements

REST API Updates: All existing Pet REST endpoints must include weight field in JSON:

- GET /api/pets/{petId} - return weight as decimal number in JSON response
- PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
- GET /api/pets - return weight for all pets in response array
- POST /api/owners/{ownerId}/pets - accept weight when creating pets
- PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates

JSON Format: Weight field should be represented as:

- Field name: weight
- Type: number (decimal)
- Optional: can be null for pets without recorded weight
- Example: "weight": 15.75 or "weight": null

## Acceptance Criteria

- All existing Pet REST endpoints include weight field in their JSON request/response payloads
- Weight field accepts decimal numbers and null values through REST API
- Weight field persists correctly - value set via POST/PUT can be retrieved via GET

## Technical Design

- Implementation: Add weight field to Pet entity, update DTO/mapper, modify database schema
- Testing: Create end-to-end tests that verify weight field behavior through the REST API endpoints listed in requirements.
- Tests must use actual HTTP requests to validate JSON request/response handling.

### FAIL_TO_PASS: 
org.springframework.samples.petclinic.rest.controller.integration.PetWeightIntegrationTests,
org.springframework.samples.petclinic.rest.controller.integration.OwnerPetWeightIntegrationTests

