### PR TITLE
Onboarding: Add weight tracking support to Pet entity [golden]

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -38,6 +38,9 @@ public class Pet extends NamedEntity {
     @Column(name = "birth_date", columnDefinition = "DATE")
     private LocalDate birthDate;
 
+    @Column(name = "weight")
+    private Double weight;
+
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "type_id")
     private PetType type;
@@ -51,6 +54,14 @@ public class Pet extends NamedEntity {
 
     public LocalDate getBirthDate() {
         return this.birthDate;
+    }
+
+    public Double getWeight() {
+        return this.weight;
+    }
+
+    public void setWeight(Double weight) {
+        this.weight = weight;
     }
 
     public void setBirthDate(LocalDate birthDate) {

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcOwnerRepositoryImpl.java
@@ -115,7 +115,7 @@ public class JdbcOwnerRepositoryImpl implements OwnerRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", owner.getId());
         final List<JdbcPet> pets = this.namedParameterJdbcTemplate.query(
-            "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
+            "SELECT pets.id as pets_id, name, birth_date, weight, type_id, owner_id, visits.id as visit_id, visit_date, description, visits.pet_id as visits_pet_id FROM pets LEFT OUTER JOIN visits ON pets.id = visits.pet_id WHERE owner_id=:id ORDER BY pets.id",
             params,
             new JdbcPetVisitExtractor()
         );

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRepositoryImpl.java
@@ -109,7 +109,7 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             pet.setId(newKey.intValue());
         } else {
             this.namedParameterJdbcTemplate.update(
-                "UPDATE pets SET name=:name, birth_date=:birth_date, type_id=:type_id, " +
+                "UPDATE pets SET name=:name, birth_date=:birth_date, weight=:weight, type_id=:type_id, " +
                     "owner_id=:owner_id WHERE id=:id",
                 createPetParameterSource(pet));
         }
@@ -123,17 +123,18 @@ public class JdbcPetRepositoryImpl implements PetRepository {
             .addValue("id", pet.getId())
             .addValue("name", pet.getName())
             .addValue("birth_date", pet.getBirthDate())
+            .addValue("weight", pet.getWeight())
             .addValue("type_id", pet.getType().getId())
             .addValue("owner_id", pet.getOwner().getId());
     }
-    
+
 	@Override
 	public Collection<Pet> findAll() throws DataAccessException {
 		Map<String, Object> params = new HashMap<>();
 		Collection<Pet> pets = new ArrayList<Pet>();
 		Collection<JdbcPet> jdbcPets = new ArrayList<JdbcPet>();
 		jdbcPets = this.namedParameterJdbcTemplate
-				.query("SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets",
+				.query("SELECT pets.id as pets_id, name, birth_date, weight, type_id, owner_id FROM pets",
 				params,
 				new JdbcPetRowMapper());
 		Collection<PetType> petTypes = this.namedParameterJdbcTemplate.query("SELECT id, name FROM types ORDER BY name",

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetRowMapper.java
@@ -34,6 +34,12 @@ public class JdbcPetRowMapper implements RowMapper<JdbcPet> {
         pet.setId(rs.getInt("pets_id"));
         pet.setName(rs.getString("name"));
         pet.setBirthDate(rs.getObject("birth_date", LocalDate.class));
+        Object weightObj = rs.getObject("weight");
+        if (weightObj != null) {
+            pet.setWeight(rs.getDouble("weight"));
+        } else {
+            pet.setWeight(null);
+        }
         pet.setTypeId(rs.getInt("type_id"));
         pet.setOwnerId(rs.getInt("owner_id"));
         return pet;

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcPetTypeRepositoryImpl.java
@@ -119,7 +119,7 @@ public class JdbcPetTypeRepositoryImpl implements PetTypeRepository {
 		pettype_params.put("id", petType.getId());
 		List<Pet> pets = new ArrayList<Pet>();
 		pets = this.namedParameterJdbcTemplate.
-    			query("SELECT pets.id, name, birth_date, type_id, owner_id FROM pets WHERE type_id=:id",
+    			query("SELECT pets.id, name, birth_date, weight, type_id, owner_id FROM pets WHERE type_id=:id",
     			pettype_params,
     			BeanPropertyRowMapper.newInstance(Pet.class));
 		// cascade delete pets

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcVisitRepositoryImpl.java
@@ -81,7 +81,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
         Map<String, Object> params = new HashMap<>();
         params.put("id", petId);
         JdbcPet pet = this.namedParameterJdbcTemplate.queryForObject(
-            "SELECT id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE id=:id",
+            "SELECT id as pets_id, name, birth_date, weight, type_id, owner_id FROM pets WHERE id=:id",
             params,
             new JdbcPetRowMapper());
 
@@ -154,7 +154,7 @@ public class JdbcVisitRepositoryImpl implements VisitRepository {
             Map<String, Object> params = new HashMap<>();
             params.put("id", rs.getInt("pets_id"));
             pet = JdbcVisitRepositoryImpl.this.namedParameterJdbcTemplate.queryForObject(
-                "SELECT pets.id as pets_id, name, birth_date, type_id, owner_id FROM pets WHERE pets.id=:id",
+                "SELECT pets.id as pets_id, name, birth_date, weight, type_id, owner_id FROM pets WHERE pets.id=:id",
                 params,
                 new JdbcPetRowMapper());
             params.put("type_id", pet.getTypeId());

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -156,6 +156,7 @@ public class OwnerRestController implements OwnersApi {
             if (currentPet != null) {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());
+                currentPet.setWeight(petFieldsDto.getWeight());
                 currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
                 this.clinicService.savePet(currentPet);
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -79,6 +79,7 @@ public class PetRestController implements PetsApi {
         }
         currentPet.setBirthDate(petDto.getBirthDate());
         currentPet.setName(petDto.getName());
+        currentPet.setWeight(petDto.getWeight());
         currentPet.setType(petMapper.toPetType(petDto.getType()));
         this.clinicService.savePet(currentPet);
         return new ResponseEntity<>(petMapper.toPetDto(currentPet), HttpStatus.NO_CONTENT);

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -44,20 +44,20 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) VALUES
 ('Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
 -- Insert Pets
-INSERT INTO pets (name, birth_date, type_id, owner_id) VALUES 
-('Leo', '2010-09-07', 1, 1),
-('Basil', '2012-08-06', 6, 2),
-('Rosy', '2011-04-17', 2, 3),
-('Jewel', '2010-03-07', 2, 3),
-('Iggy', '2010-11-30', 3, 4),
-('George', '2010-01-20', 4, 5),
-('Samantha', '2012-09-04', 1, 6),
-('Max', '2012-09-04', 1, 6),
-('Lucky', '2011-08-06', 5, 7),
-('Mulligan', '2007-02-24', 2, 8),
-('Freddy', '2010-03-09', 5, 9),
-('Lucky', '2010-06-24', 2, 10),
-('Sly', '2012-06-08', 1, 10);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) VALUES
+('Leo', '2010-09-07', NULL, 1, 1),
+('Basil', '2012-08-06', NULL, 6, 2),
+('Rosy', '2011-04-17', NULL, 2, 3),
+('Jewel', '2010-03-07', NULL, 2, 3),
+('Iggy', '2010-11-30', NULL, 3, 4),
+('George', '2010-01-20', NULL, 4, 5),
+('Samantha', '2012-09-04', NULL, 1, 6),
+('Max', '2012-09-04', NULL, 1, 6),
+('Lucky', '2011-08-06', NULL, 5, 7),
+('Mulligan', '2007-02-24', NULL, 2, 8),
+('Freddy', '2010-03-09', NULL, 5, 9),
+('Lucky', '2010-06-24', NULL, 2, 10),
+('Sly', '2012-06-08', NULL, 1, 10);
 
 -- Insert Visits
 INSERT INTO visits (pet_id, visit_date, description) VALUES 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -72,3 +72,5 @@ CREATE TABLE IF NOT EXISTS roles (
   UNIQUE (role, username),
   FOREIGN KEY (username) REFERENCES users(username) ON DELETE CASCADE
 );
+
+ALTER TABLE pets ADD COLUMN IF NOT EXISTS weight DOUBLE;

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madison', '
 INSERT INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1);
-INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2);
-INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3);
-INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3);
-INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4);
-INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5);
-INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6);
-INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7);
-INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8);
-INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9);
-INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10);
-INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10);
+INSERT INTO pets VALUES (1, 'Leo', '2010-09-07', 1, 1, NULL);
+INSERT INTO pets VALUES (2, 'Basil', '2012-08-06', 6, 2, NULL);
+INSERT INTO pets VALUES (3, 'Rosy', '2011-04-17', 2, 3, NULL);
+INSERT INTO pets VALUES (4, 'Jewel', '2010-03-07', 2, 3, NULL);
+INSERT INTO pets VALUES (5, 'Iggy', '2010-11-30', 3, 4, NULL);
+INSERT INTO pets VALUES (6, 'George', '2010-01-20', 4, 5, NULL);
+INSERT INTO pets VALUES (7, 'Samantha', '2012-09-04', 1, 6, NULL);
+INSERT INTO pets VALUES (8, 'Max', '2012-09-04', 1, 6, NULL);
+INSERT INTO pets VALUES (9, 'Lucky', '2011-08-06', 5, 7, NULL);
+INSERT INTO pets VALUES (10, 'Mulligan', '2007-02-24', 2, 8, NULL);
+INSERT INTO pets VALUES (11, 'Freddy', '2010-03-09', 5, 9, NULL);
+INSERT INTO pets VALUES (12, 'Lucky', '2010-06-24', 2, 10, NULL);
+INSERT INTO pets VALUES (13, 'Sly', '2012-06-08', 1, 10, NULL);
 
 INSERT INTO visits VALUES (1, 7, '2013-01-01', 'rabies shot');
 INSERT INTO visits VALUES (2, 8, '2013-01-02', 'rabies shot');

--- a/src/main/resources/db/hsqldb/schema.sql
+++ b/src/main/resources/db/hsqldb/schema.sql
@@ -80,3 +80,5 @@ CREATE TABLE roles (
 ALTER TABLE roles ADD CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES users (username);
 CREATE INDEX fk_username_idx ON roles (username);
 
+ALTER TABLE pets ADD COLUMN weight DOUBLE;
+

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -33,19 +33,19 @@ INSERT IGNORE INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madi
 INSERT IGNORE INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT IGNORE INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1);
-INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2);
-INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3);
-INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3);
-INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4);
-INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5);
-INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7);
-INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8);
-INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9);
-INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10);
-INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10);
+INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1, NULL);
+INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2, NULL);
+INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3, NULL);
+INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3, NULL);
+INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4, NULL);
+INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5, NULL);
+INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6, NULL);
+INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6, NULL);
+INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7, NULL);
+INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8, NULL);
+INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9, NULL);
+INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10, NULL);
+INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10, NULL);
 
 INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot');
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot');

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -70,3 +70,5 @@ CREATE TABLE IF NOT EXISTS roles (
   KEY fk_username_idx (username),
   CONSTRAINT fk_username FOREIGN KEY (username) REFERENCES users (username)
 ) engine=InnoDB;
+
+ALTER TABLE pets ADD COLUMN IF NOT EXISTS weight DOUBLE PRECISION;

--- a/src/main/resources/db/postgres/data.sql
+++ b/src/main/resources/db/postgres/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Mar
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=9);
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=10);
 
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Leo', '2000-09-07', 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Basil', '2002-08-06', 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Rosy', '2001-04-17', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Jewel', '2000-03-07', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Iggy', '2000-11-30', 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'George', '2000-01-20', 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Samantha', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Max', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '1999-08-06', 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Freddy', '2000-03-09', 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '2000-06-24', 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Sly', '2002-06-08', 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Leo', '2000-09-07', NULL, 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Basil', '2002-08-06', NULL, 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Rosy', '2001-04-17', NULL, 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Jewel', '2000-03-07', NULL, 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Iggy', '2000-11-30', NULL, 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'George', '2000-01-20', NULL, 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Samantha', '1995-09-04', NULL, 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Max', '1995-09-04', NULL, 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Lucky', '1999-08-06', NULL, 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', NULL, 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Freddy', '2000-03-09', NULL, 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Lucky', '2000-06-24', NULL, 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
+INSERT INTO pets (name, birth_date, weight, type_id, owner_id) SELECT 'Sly', '2002-06-08', NULL, 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
 
 INSERT INTO visits (pet_id, visit_date, description) SELECT 7, '2010-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=1);
 INSERT INTO visits (pet_id, visit_date, description) SELECT 8, '2011-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=2);

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -65,3 +65,5 @@ CREATE TABLE IF NOT EXISTS roles (
   FOREIGN KEY (username) REFERENCES users (username),
   CONSTRAINT uni_username_role UNIQUE (role, username)
 );
+
+ALTER TABLE pets ADD COLUMN IF NOT EXISTS weight DOUBLE PRECISION;

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1953,6 +1953,13 @@ components:
           type: string
           format: date
           example: '2010-09-07'
+        weight:
+          title: Weight
+          description: The weight of the pet in decimal number format.
+          type: number
+          format: double
+          nullable: true
+          example: 15.75
         type:
           $ref: '#/components/schemas/PetType'
       required:

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetWeightIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetWeightIntegrationTests.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.SimpleDateFormat;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration tests for Pet weight field functionality across all REST endpoints.
+ * Tests verify that weight field is properly handled in JSON request/response payloads.
+ *
+ * @author Nwatu Ernest I.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
+@Transactional
+class PetWeightIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetPetByIdWithWeight() throws Exception {
+        String createJson = """
+            {
+                "name": "Weere",
+                "birthDate": "2022-01-15",
+                "weight": 12.75,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        String response = mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        int petId = objectMapper.readTree(response).get("id").asInt();
+
+        mockMvc.perform(get("/api/pets/" + petId)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").value(12.75));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetPetByIdWithoutWeight() throws Exception {
+        String createJson = """
+            {
+                "name": "Bolle",
+                "birthDate": "2023-01-15",
+                "weight": null,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        String response = mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        int petId = objectMapper.readTree(response).get("id").asInt();
+
+        mockMvc.perform(get("/api/pets/" + petId)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetAllPetsWithWeight() throws Exception {
+        mockMvc.perform(get("/api/pets")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$").isArray())
+            .andExpect(jsonPath("$[*].weight").exists())
+            .andExpect(result -> {
+                String content = result.getResponse().getContentAsString();
+                var pets = objectMapper.readTree(content);
+                if (!pets.isEmpty()) {
+                    var weight = pets.get(0).get("weight");
+                    if (!weight.isNull() && !weight.isNumber()) {
+                        throw new AssertionError("Weight must be either a number or null");
+                    }
+                }
+            });
+
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithWeight() throws Exception {
+        String updateJson = """
+            {
+                "id": 1,
+                "name": "Venna",
+                "birthDate": "2020-01-15",
+                "weight": 18.95,
+                "type": {"id": 1, "name": "cat"},
+                "ownerId": 1
+            }
+            """;
+
+        mockMvc.perform(put("/api/pets/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateJson))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/pets/1")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").value(18.95));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWithNullWeight() throws Exception {
+        String updateJson = """
+            {
+                "id": 1,
+                "name": "Biggie",
+                "birthDate": "2019-05-20",
+                "weight": null,
+                "type": {"id": 1, "name": "cat"},
+                "ownerId": 1
+            }
+            """;
+
+        mockMvc.perform(put("/api/pets/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateJson))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/pets/1")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithWeight() throws Exception {
+        String json = """
+            {
+                "name": "Darey",
+                "birthDate": "2023-01-01",
+                "weight": 4.25,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.weight").value(4.25));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithNullWeight() throws Exception {
+        String json = """
+            {
+                "name": "Miles",
+                "birthDate": "2023-02-01",
+                "weight": null,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testCreatePetWithoutWeightField() throws Exception {
+        String json = """
+            {
+                "name": "Samil",
+                "birthDate": "2023-03-01",
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetViaOwnerEndpointWithWeight() throws Exception {
+        String json = """
+            {
+                "name": "Rex",
+                "birthDate": "2018-06-15",
+                "weight": 22.5,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(put("/api/owners/1/pets/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/api/owners/1/pets/1")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").value(22.5));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetPetViaOwnerEndpointWithWeight() throws Exception {
+        String createJson = """
+            {
+                "name": "Fluffy",
+                "birthDate": "2022-01-01",
+                "weight": 12.75,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        String response = mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createJson))
+            .andExpect(status().isCreated())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        int petId = objectMapper.readTree(response).get("id").asInt();
+
+        mockMvc.perform(get("/api/owners/1/pets/" + petId)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").value(12.75));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testWeightZero() throws Exception {
+        String json = """
+            {
+                "name": "Slim",
+                "birthDate": "2023-01-01",
+                "weight": 0.0,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.weight").value(0.0));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testWeightDecimalPrecision() throws Exception {
+        String json = """
+            {
+                "name": "Zare",
+                "birthDate": "2023-01-01",
+                "weight": 12.34567,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.weight").exists())
+            .andExpect(jsonPath("$.weight").isNumber())
+            .andExpect(jsonPath("$.weight").value(12.34567));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testWeightFieldDoesNotAffectOtherFields() throws Exception {
+        String json = """
+            {
+                "name": "Filone",
+                "birthDate": "2020-01-15",
+                "weight": 25.5,
+                "type": {"id": 1, "name": "cat"}
+            }
+            """;
+
+        mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.name").value("Filone"))
+            .andExpect(jsonPath("$.birthDate").exists())
+            .andExpect(jsonPath("$.type.id").value(1))
+            .andExpect(jsonPath("$.type.name").value("cat"))
+            .andExpect(jsonPath("$.weight").value(25.5));
+    }
+}


### PR DESCRIPTION
### Add weight tracking support to Pet entity #0

Objective: Add weight tracking support to the Pet entity in the Spring PetClinic REST API to enable veterinarians to monitor pet weight over time.

Requirements:
REST API Updates: All existing Pet REST endpoints must include weight field in JSON:
GET /api/pets/{petId} - return weight as decimal number in JSON response
PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
GET /api/pets - return weight for all pets in response array
POST /api/owners/{ownerId}/pets - accept weight when creating pets
PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates

JSON Format: Weight field should be represented as:
Field name: weight
Type: number (decimal)
Optional: can be null for pets without recorded weight
Example: "weight": 15.75 or "weight": null

FAIL_TO_PASS: org.springframework.samples.petclinic.rest.controller.PetWeightIntegrationTests