### PR TITLE
Onboarding: Add Pet Weight [agent]

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -20,6 +20,7 @@ import org.springframework.beans.support.PropertyComparator;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import jakarta.persistence.*;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -46,6 +47,9 @@ public class Pet extends NamedEntity {
     @JoinColumn(name = "owner_id")
     private Owner owner;
 
+    @Column(name = "weight")
+    private BigDecimal weight;
+
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
     private Set<Visit> visits;
 
@@ -71,6 +75,14 @@ public class Pet extends NamedEntity {
 
     public void setOwner(Owner owner) {
         this.owner = owner;
+    }
+
+    public BigDecimal getWeight() {
+        return this.weight;
+    }
+
+    public void setWeight(BigDecimal weight) {
+        this.weight = weight;
     }
 
     protected Set<Visit> getVisitsInternal() {

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/OwnerRestController.java
@@ -157,6 +157,7 @@ public class OwnerRestController implements OwnersApi {
                 currentPet.setBirthDate(petFieldsDto.getBirthDate());
                 currentPet.setName(petFieldsDto.getName());
                 currentPet.setType(petMapper.toPetType(petFieldsDto.getType()));
+                currentPet.setWeight(petFieldsDto.getWeight());
                 this.clinicService.savePet(currentPet);
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             }

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -80,6 +80,7 @@ public class PetRestController implements PetsApi {
         currentPet.setBirthDate(petDto.getBirthDate());
         currentPet.setName(petDto.getName());
         currentPet.setType(petMapper.toPetType(petDto.getType()));
+        currentPet.setWeight(petDto.getWeight());
         this.clinicService.savePet(currentPet);
         return new ResponseEntity<>(petMapper.toPetDto(currentPet), HttpStatus.NO_CONTENT);
     }

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -44,20 +44,20 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) VALUES
 ('Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
 -- Insert Pets
-INSERT INTO pets (name, birth_date, type_id, owner_id) VALUES 
-('Leo', '2010-09-07', 1, 1),
-('Basil', '2012-08-06', 6, 2),
-('Rosy', '2011-04-17', 2, 3),
-('Jewel', '2010-03-07', 2, 3),
-('Iggy', '2010-11-30', 3, 4),
-('George', '2010-01-20', 4, 5),
-('Samantha', '2012-09-04', 1, 6),
-('Max', '2012-09-04', 1, 6),
-('Lucky', '2011-08-06', 5, 7),
-('Mulligan', '2007-02-24', 2, 8),
-('Freddy', '2010-03-09', 5, 9),
-('Lucky', '2010-06-24', 2, 10),
-('Sly', '2012-06-08', 1, 10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) VALUES 
+('Leo', '2010-09-07', 1, 1, 5.5),
+('Basil', '2012-08-06', 6, 2, NULL),
+('Rosy', '2011-04-17', 2, 3, 15.75),
+('Jewel', '2010-03-07', 2, 3, 12.3),
+('Iggy', '2010-11-30', 3, 4, NULL),
+('George', '2010-01-20', 4, 5, NULL),
+('Samantha', '2012-09-04', 1, 6, 8.2),
+('Max', '2012-09-04', 1, 6, 9.1),
+('Lucky', '2011-08-06', 5, 7, NULL),
+('Mulligan', '2007-02-24', 2, 8, 25.0),
+('Freddy', '2010-03-09', 5, 9, NULL),
+('Lucky', '2010-06-24', 2, 10, 18.5),
+('Sly', '2012-06-08', 1, 10, 6.8);
 
 -- Insert Visits
 INSERT INTO visits (pet_id, visit_date, description) VALUES 

--- a/src/main/resources/db/h2/schema.sql
+++ b/src/main/resources/db/h2/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE NOT NULL,
   type_id INTEGER NOT NULL,
   owner_id INTEGER NOT NULL,
+  weight DECIMAL(5,2),
   FOREIGN KEY (owner_id) REFERENCES owners(id) ON DELETE CASCADE,
   FOREIGN KEY (type_id) REFERENCES types(id) ON DELETE CASCADE
 );

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -33,19 +33,19 @@ INSERT IGNORE INTO owners VALUES (8, 'Maria', 'Escobito', '345 Maple St.', 'Madi
 INSERT IGNORE INTO owners VALUES (9, 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435');
 INSERT IGNORE INTO owners VALUES (10, 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487');
 
-INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1);
-INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2);
-INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3);
-INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3);
-INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4);
-INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5);
-INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6);
-INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7);
-INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8);
-INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9);
-INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10);
-INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10);
+INSERT IGNORE INTO pets VALUES (1, 'Leo', '2000-09-07', 1, 1, 5.5);
+INSERT IGNORE INTO pets VALUES (2, 'Basil', '2002-08-06', 6, 2, NULL);
+INSERT IGNORE INTO pets VALUES (3, 'Rosy', '2001-04-17', 2, 3, 15.75);
+INSERT IGNORE INTO pets VALUES (4, 'Jewel', '2000-03-07', 2, 3, 12.3);
+INSERT IGNORE INTO pets VALUES (5, 'Iggy', '2000-11-30', 3, 4, NULL);
+INSERT IGNORE INTO pets VALUES (6, 'George', '2000-01-20', 4, 5, NULL);
+INSERT IGNORE INTO pets VALUES (7, 'Samantha', '1995-09-04', 1, 6, 8.2);
+INSERT IGNORE INTO pets VALUES (8, 'Max', '1995-09-04', 1, 6, 9.1);
+INSERT IGNORE INTO pets VALUES (9, 'Lucky', '1999-08-06', 5, 7, NULL);
+INSERT IGNORE INTO pets VALUES (10, 'Mulligan', '1997-02-24', 2, 8, 25.0);
+INSERT IGNORE INTO pets VALUES (11, 'Freddy', '2000-03-09', 5, 9, NULL);
+INSERT IGNORE INTO pets VALUES (12, 'Lucky', '2000-06-24', 2, 10, 18.5);
+INSERT IGNORE INTO pets VALUES (13, 'Sly', '2002-06-08', 1, 10, 6.8);
 
 INSERT IGNORE INTO visits VALUES (1, 7, '2010-03-04', 'rabies shot');
 INSERT IGNORE INTO visits VALUES (2, 8, '2011-03-04', 'rabies shot');

--- a/src/main/resources/db/mysql/schema.sql
+++ b/src/main/resources/db/mysql/schema.sql
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pets (
   birth_date DATE,
   type_id INT(4) UNSIGNED NOT NULL,
   owner_id INT(4) UNSIGNED NOT NULL,
+  weight DECIMAL(5,2),
   INDEX(name),
   FOREIGN KEY (owner_id) REFERENCES owners(id),
   FOREIGN KEY (type_id) REFERENCES types(id)

--- a/src/main/resources/db/postgres/data.sql
+++ b/src/main/resources/db/postgres/data.sql
@@ -33,19 +33,19 @@ INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Mar
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'David', 'Schroeder', '2749 Blackhawk Trail', 'Madison', '6085559435' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=9);
 INSERT INTO owners (first_name, last_name, address, city, telephone) SELECT 'Carlos', 'Estaban', '2335 Independence La.', 'Waunakee', '6085555487' WHERE NOT EXISTS (SELECT * FROM owners WHERE id=10);
 
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Leo', '2000-09-07', 1, 1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Basil', '2002-08-06', 6, 2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Rosy', '2001-04-17', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Jewel', '2000-03-07', 2, 3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Iggy', '2000-11-30', 3, 4 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'George', '2000-01-20', 4, 5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Samantha', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Max', '1995-09-04', 1, 6 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '1999-08-06', 5, 7 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Mulligan', '1997-02-24', 2, 8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Freddy', '2000-03-09', 5, 9 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Lucky', '2000-06-24', 2, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
-INSERT INTO pets (name, birth_date, type_id, owner_id) SELECT 'Sly', '2002-06-08', 1, 10 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Leo', '2000-09-07', 1, 1, 5.5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=1);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Basil', '2002-08-06', 6, 2, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=2);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Rosy', '2001-04-17', 2, 3, 15.75 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=3);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Jewel', '2000-03-07', 2, 3, 12.3 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=4);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Iggy', '2000-11-30', 3, 4, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=5);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'George', '2000-01-20', 4, 5, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=6);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Samantha', '1995-09-04', 1, 6, 8.2 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=7);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Max', '1995-09-04', 1, 6, 9.1 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=8);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '1999-08-06', 5, 7, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=9);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Mulligan', '1997-02-24', 2, 8, 25.0 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=10);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Freddy', '2000-03-09', 5, 9, NULL WHERE NOT EXISTS (SELECT * FROM pets WHERE id=11);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Lucky', '2000-06-24', 2, 10, 18.5 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=12);
+INSERT INTO pets (name, birth_date, type_id, owner_id, weight) SELECT 'Sly', '2002-06-08', 1, 10, 6.8 WHERE NOT EXISTS (SELECT * FROM pets WHERE id=13);
 
 INSERT INTO visits (pet_id, visit_date, description) SELECT 7, '2010-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=1);
 INSERT INTO visits (pet_id, visit_date, description) SELECT 8, '2011-03-04', 'rabies shot' WHERE NOT EXISTS (SELECT * FROM visits WHERE id=2);

--- a/src/main/resources/db/postgres/schema.sql
+++ b/src/main/resources/db/postgres/schema.sql
@@ -38,7 +38,8 @@ CREATE TABLE IF NOT EXISTS pets (
                                     name       TEXT,
                                     birth_date DATE,
                                     type_id    INT NOT NULL REFERENCES types (id),
-                                    owner_id   INT REFERENCES owners (id)
+                                    owner_id   INT REFERENCES owners (id),
+                                    weight     DECIMAL(5,2)
 );
 CREATE INDEX ON pets (name);
 CREATE INDEX ON pets (owner_id);

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1955,6 +1955,12 @@ components:
           example: '2010-09-07'
         type:
           $ref: '#/components/schemas/PetType'
+        weight:
+          title: Weight
+          description: The weight of the pet in kilograms.
+          type: number
+          format: decimal
+          example: 15.75
       required:
         - name
         - birthDate

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetWeightRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetWeightRestControllerTests.java
@@ -1,0 +1,176 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.mapper.PetMapper;
+import org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdvice;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.samples.petclinic.rest.dto.PetTypeDto;
+import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ContextConfiguration(classes = ApplicationTestConfig.class)
+@WebAppConfiguration
+class PetWeightRestControllerTests {
+
+    @MockitoBean
+    protected ClinicService clinicService;
+
+    @Autowired
+    private PetRestController petRestController;
+
+    @Autowired
+    private PetMapper petMapper;
+
+    private MockMvc mockMvc;
+
+    private ObjectMapper mapper;
+
+    private PetDto petWithWeight;
+    private PetDto petWithNullWeight;
+
+    @BeforeEach
+    void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(petRestController)
+            .setControllerAdvice(new ExceptionControllerAdvice())
+            .build();
+
+        mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        PetTypeDto petType = new PetTypeDto();
+        petType.id(2).name("dog");
+
+        petWithWeight = new PetDto();
+        petWithWeight.id(3)
+            .name("Rosy")
+            .birthDate(LocalDate.now())
+            .type(petType)
+            .weight(new BigDecimal("15.75"));
+
+        petWithNullWeight = new PetDto();
+        petWithNullWeight.id(4)
+            .name("Jewel")
+            .birthDate(LocalDate.now())
+            .type(petType);
+        // weight intentionally left null
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetPetReturnsWeight() throws Exception {
+        given(this.clinicService.findPetById(3))
+            .willReturn(petMapper.toPet(petWithWeight));
+
+        this.mockMvc.perform(get("/api/pets/3")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.id").value(3))
+            .andExpect(jsonPath("$.weight").value(15.75));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetPetReturnsNullWeight() throws Exception {
+        given(this.clinicService.findPetById(4))
+            .willReturn(petMapper.toPet(petWithNullWeight));
+
+        this.mockMvc.perform(get("/api/pets/4")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testGetAllPetsReturnsWeight() throws Exception {
+        List<PetDto> pets = new ArrayList<>();
+        pets.add(petWithWeight);
+        pets.add(petWithNullWeight);
+
+        Collection<org.springframework.samples.petclinic.model.Pet> petEntities =
+            petMapper.toPets(pets);
+        given(this.clinicService.findAllPets()).willReturn(petEntities);
+
+        this.mockMvc.perform(get("/api/pets")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.[0].weight").value(15.75))
+            .andExpect(jsonPath("$.[1].weight").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWeightSuccess() throws Exception {
+        given(this.clinicService.findPetById(3))
+            .willReturn(petMapper.toPet(petWithWeight));
+
+        PetDto updatedPet = petWithWeight;
+        updatedPet.setWeight(new BigDecimal("20.00"));
+
+        String updatedPetJson = mapper.writeValueAsString(updatedPet);
+
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(updatedPetJson)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+
+        this.mockMvc.perform(get("/api/pets/3")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").value(20.00));
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void testUpdatePetWeightToNull() throws Exception {
+        given(this.clinicService.findPetById(3))
+            .willReturn(petMapper.toPet(petWithWeight));
+
+        PetDto updatedPet = petWithWeight;
+        updatedPet.setWeight(null);
+
+        String updatedPetJson = mapper.writeValueAsString(updatedPet);
+
+        this.mockMvc.perform(put("/api/pets/3")
+                .content(updatedPetJson)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+
+        this.mockMvc.perform(get("/api/pets/3")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.weight").isEmpty());
+    }
+}


### PR DESCRIPTION
Task Description:
Objective
Add weight tracking support to the Pet entity in the Spring PetClinic REST API to enable veterinarians to monitor pet weight over time.

Requirements
REST API Updates: All existing Pet REST endpoints must include weight field in JSON:
GET /api/pets/{petId} - return weight as decimal number in JSON response
PUT /api/pets/{petId} - accept weight as decimal number in JSON request body
GET /api/pets - return weight for all pets in response array
POST /api/owners/{ownerId}/pets - accept weight when creating pets
PUT /api/owners/{ownerId}/pets/{petId} - accept weight in updates
JSON Format: Weight field should be represented as:
Field name: weight
Type: number (decimal)
Optional: can be null for pets without recorded weight
Example: "weight": 15.75 or "weight": null
Acceptance Criteria
All existing Pet REST endpoints include weight field in their JSON request/response payloads
Weight field accepts decimal numbers and null values through REST API
Weight field persists correctly - value set via POST/PUT can be retrieved via GET
Task Design:
Technical Design
Implementation: Add weight field to Pet entity, update DTO/mapper, modify database schema
Testing: Create end-to-end tests that verify weight field behavior through the REST API endpoints listed in requirements. Tests must use actual HTTP requests to validate JSON request/response handling.

implement in one pass only.